### PR TITLE
Replace RBAC namespace variable with .Release.Namespace meta

### DIFF
--- a/kubernetes/chart/IngressMonitorController/templates/rbac.yaml
+++ b/kubernetes/chart/IngressMonitorController/templates/rbac.yaml
@@ -49,4 +49,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "name" . }}
-    namespace: {{ .Values.ingressMonitorController.namespace }}
+    namespace: {{ .Release.Namespace | quote }}

--- a/kubernetes/chart/IngressMonitorController/values.yaml
+++ b/kubernetes/chart/IngressMonitorController/values.yaml
@@ -4,7 +4,6 @@ kubernetes:
   host: https://kubernetes.default
 
 ingressMonitorController:
-  namespace: default
   labels:
     provider: stakater
     group: com.stakater.platform

--- a/kubernetes/templates/chart/values.yaml.tmpl
+++ b/kubernetes/templates/chart/values.yaml.tmpl
@@ -4,7 +4,6 @@ kubernetes:
   host: https://kubernetes.default
 
 ingressMonitorController:
-  namespace: default
   labels:
     provider: stakater
     group: com.stakater.platform


### PR DESCRIPTION
The variable was only used in RBAC spec. This change simplifies the deployment to a different namespace and prevents RBAC errors when the release ns and variable mismatch.

I also included a commit that bumps the version because the helm chart changed as I'm not sure what your release process is. If you would rather have a PR with just the first commit (6cb1636) let me know.