### PR TITLE
Watch all namespaces

### DIFF
--- a/kubernetes/chart/IngressMonitorController/templates/deployment.yaml
+++ b/kubernetes/chart/IngressMonitorController/templates/deployment.yaml
@@ -32,9 +32,7 @@ spec:
       containers:
       - env:
         - name: KUBERNETES_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
+          value: {{ default .Values.ingressMonitorController.watchNamespace .Release.Namespace | quote }}
         - name: CONFIG_FILE_PATH
           value: {{ .Values.ingressMonitorController.configFilePath }}
         image: "{{ .Values.ingressMonitorController.image.name }}:{{ .Values.ingressMonitorController.image.tag }}"

--- a/kubernetes/chart/IngressMonitorController/templates/rbac.yaml
+++ b/kubernetes/chart/IngressMonitorController/templates/rbac.yaml
@@ -15,6 +15,9 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:
   name: {{ template "name" . }}-role
+  {{ if .Values.ingressMonitorController.watchNamespace }}
+  namespace: {{ .Values.ingressMonitorController.watchNamespace | quote }}
+  {{ end }}
 rules:
   - apiGroups:
       - ""
@@ -42,6 +45,9 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
   name: {{ template "name" . }}-role-binding
+  {{ if .Values.ingressMonitorController.watchNamespace }}
+  namespace: {{ .Values.ingressMonitorController.watchNamespace | quote }}
+  {{ end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/kubernetes/chart/IngressMonitorController/values.yaml
+++ b/kubernetes/chart/IngressMonitorController/values.yaml
@@ -4,6 +4,7 @@ kubernetes:
   host: https://kubernetes.default
 
 ingressMonitorController:
+  watchNamespace: "default"
   labels:
     provider: stakater
     group: com.stakater.platform

--- a/kubernetes/templates/chart/values.yaml.tmpl
+++ b/kubernetes/templates/chart/values.yaml.tmpl
@@ -4,6 +4,7 @@ kubernetes:
   host: https://kubernetes.default
 
 ingressMonitorController:
+  watchNamespace: "default"
   labels:
     provider: stakater
     group: com.stakater.platform

--- a/src/controller.go
+++ b/src/controller.go
@@ -136,9 +136,9 @@ func (c *MonitorController) handleIngress(key string) error {
 func (c *MonitorController) handleIngressOnDeletion(key string) {
 	if c.config.EnableMonitorDeletion {
 		// Delete the monitor if it exists
-		// key is in the format "namespace/ingressname"
+		// key is in the format "namespace/ingressname" (see cache store MetaNamespaceKeyFunc)
 		splitted := strings.Split(key, "/")
-		monitorName := c.getMonitorName(splitted[1], c.namespace)
+		monitorName := c.getMonitorName(splitted[1], splitted[0])
 
 		c.removeMonitorsIfExist(monitorName)
 	}
@@ -155,7 +155,7 @@ func (c *MonitorController) getMonitorName(ingressName string, namespace string)
 func (c *MonitorController) getMonitorURL(ingress *v1beta1.Ingress) string {
 	ingressWrapper := IngressWrapper{
 		ingress:   ingress,
-		namespace: c.namespace,
+		namespace: ingress.Namespace,
 		clientset: c.clientset,
 	}
 
@@ -163,7 +163,7 @@ func (c *MonitorController) getMonitorURL(ingress *v1beta1.Ingress) string {
 }
 
 func (c *MonitorController) handleIngressOnCreationOrUpdation(ingress *v1beta1.Ingress) {
-	monitorName := c.getMonitorName(ingress.GetName(), c.namespace)
+	monitorName := c.getMonitorName(ingress.GetName(), ingress.Namespace)
 	monitorURL := c.getMonitorURL(ingress)
 
 	log.Println("Monitor Name: " + monitorName)

--- a/src/ingress-wrapper.go
+++ b/src/ingress-wrapper.go
@@ -122,7 +122,7 @@ func (iw *IngressWrapper) tryGetHealthEndpointFromIngress() (string, bool) {
 		return "", false
 	}
 
-	service, err := iw.clientset.Core().Services(iw.namespace).Get(serviceName, meta_v1.GetOptions{})
+	service, err := iw.clientset.Core().Services(iw.ingress.Namespace).Get(serviceName, meta_v1.GetOptions{})
 	if err != nil {
 		log.Printf("Get service from kubernetes cluster error:%v", err)
 		return "", false
@@ -130,7 +130,7 @@ func (iw *IngressWrapper) tryGetHealthEndpointFromIngress() (string, bool) {
 
 	set := labels.Set(service.Spec.Selector)
 
-	if pods, err := iw.clientset.Core().Pods(iw.namespace).List(meta_v1.ListOptions{LabelSelector: set.AsSelector().String()}); err != nil {
+	if pods, err := iw.clientset.Core().Pods(iw.ingress.Namespace).List(meta_v1.ListOptions{LabelSelector: set.AsSelector().String()}); err != nil {
 		log.Printf("List Pods of service[%s] error:%v", service.GetName(), err)
 	} else if len(pods.Items) > 0 {
 		pod := pods.Items[0]

--- a/src/main.go
+++ b/src/main.go
@@ -6,12 +6,14 @@ import (
 
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func main() {
 	currentNamespace := os.Getenv("KUBERNETES_NAMESPACE")
 	if len(currentNamespace) == 0 {
-		log.Fatal("Could not find the current namespace")
+		currentNamespace = v1.NamespaceAll
+		log.Println("Warning: KUBERNETES_NAMESPACE is unset, will monitor ingresses in all namespaces.")
 	}
 
 	// create the in-cluster config


### PR DESCRIPTION
The `watchNamespace` (_ns to watch_) option is different from the original `namespace` (_ns to deploy to_) option.

TODO:
- [x] fix monitor removal, currently missing namespace
