### PR TITLE
Fix URL joins

### DIFF
--- a/src/ingress-wrapper.go
+++ b/src/ingress-wrapper.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"log"
+	"net/url"
 	"path"
 
 	"k8s.io/api/extensions/v1beta1"
@@ -75,16 +76,16 @@ func (iw *IngressWrapper) getURL() string {
 		return ""
 	}
 
-	var url string
+	var URL string
 
 	if host, exists := iw.tryGetTLSHost(); exists { // Get TLS Host if it exists
-		url = host
+		URL = host
 	} else {
-		url = iw.getHost() // Fallback for normal Host
+		URL = iw.getHost() // Fallback for normal Host
 	}
 
 	// Convert url to url object
-	u, err := url.Parse(url)
+	u, err := url.Parse(URL)
 
 	if err != nil {
 		log.Printf("URL parsing error in getURL() :%v", err)

--- a/src/ingress-wrapper.go
+++ b/src/ingress-wrapper.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"log"
+	"path"
 
 	"k8s.io/api/extensions/v1beta1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -82,25 +83,33 @@ func (iw *IngressWrapper) getURL() string {
 		url = iw.getHost() // Fallback for normal Host
 	}
 
+	// Convert url to url object
+	u, err := url.Parse(url)
+
+	if err != nil {
+		log.Printf("URL parsing error in getURL() :%v", err)
+		return ""
+	}
+
 	// Append port + ingressSubPath
-	url += iw.getIngressSubPathWithPort()
+	u.Path = path.Join(u.Path, iw.getIngressSubPathWithPort())
 
 	// Find pod by backtracking ingress -> service -> pod
 	healthEndpoint, exists := iw.tryGetHealthEndpointFromIngress()
 
 	// Health endpoint from pod successful
 	if exists {
-		url += healthEndpoint
+		u.Path = path.Join(u.Path, healthEndpoint)
 	} else { // Try to get annotation and set
 		annotations := iw.ingress.GetAnnotations()
 
 		// Annotation for health Endpoint exists
 		if value, ok := annotations[monitorHealthAnnotation]; ok {
-			url += value
+			u.Path = path.Join(u.Path, value)
 		}
 	}
 
-	return url
+	return u.String()
 }
 
 func (iw *IngressWrapper) hasService() (string, bool) {

--- a/src/ingress-wrapper_test.go
+++ b/src/ingress-wrapper_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"testing"
+
+	"k8s.io/api/extensions/v1beta1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	testUrl = "testurl.stackator.com"
+)
+
+func createIngressObjectWithPath(ingressName string, namespace string, url string) *v1beta1.Ingress {
+	ingress := &v1beta1.Ingress{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:      ingressName,
+			Namespace: namespace,
+		},
+		Spec: v1beta1.IngressSpec{
+			Rules: []v1beta1.IngressRule{
+				v1beta1.IngressRule{
+					Host: url,
+					HTTP: &v1beta1.HTTPIngressRuleValue{
+						paths: []v1beta1.HTTPIngressPath{
+							v1beta1.HTTPIngressPath{
+								path: "/",
+								backend: &v1beta1.IngressBackend{
+									serviceName: "test",
+									servicePort: "80",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	return ingress
+}
+
+func TestIngressWrapper_getURL(t *testing.T) {
+	type fields struct {
+		ingress    *v1beta1.Ingress
+		namespace  string
+		kubeClient kubernetes.Interface
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+	}{
+		// TODO: Add test cases.
+		{
+			name: "TestGetUrlWithPath",
+			fields: fields{
+				ingress:    createIngressObjectWithPath("testIngress", "test", testUrl),
+				namespace:  "test",
+				kubeClient: nil,
+			},
+			want: "want",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			iw := &IngressWrapper{
+				ingress:    tt.fields.ingress,
+				namespace:  tt.fields.namespace,
+				kubeClient: tt.fields.kubeClient,
+			}
+			if got := iw.getURL(); got != tt.want {
+				t.Errorf("IngressWrapper.getURL() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/src/ingress-wrapper_test.go
+++ b/src/ingress-wrapper_test.go
@@ -5,6 +5,7 @@ import (
 
 	"k8s.io/api/extensions/v1beta1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -22,13 +23,15 @@ func createIngressObjectWithPath(ingressName string, namespace string, url strin
 			Rules: []v1beta1.IngressRule{
 				v1beta1.IngressRule{
 					Host: url,
-					HTTP: &v1beta1.HTTPIngressRuleValue{
-						paths: []v1beta1.HTTPIngressPath{
-							v1beta1.HTTPIngressPath{
-								path: "/",
-								backend: &v1beta1.IngressBackend{
-									serviceName: "test",
-									servicePort: "80",
+					IngressRuleValue: v1beta1.IngressRuleValue{
+						HTTP: &v1beta1.HTTPIngressRuleValue{
+							Paths: []v1beta1.HTTPIngressPath{
+								v1beta1.HTTPIngressPath{
+									Path: "/",
+									Backend: v1beta1.IngressBackend{
+										ServiceName: "test",
+										ServicePort: intstr.FromInt(80),
+									},
 								},
 							},
 						},

--- a/src/ingress-wrapper_test.go
+++ b/src/ingress-wrapper_test.go
@@ -7,6 +7,7 @@ import (
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 )
 
 const (
@@ -61,9 +62,9 @@ func TestIngressWrapper_getURL(t *testing.T) {
 			fields: fields{
 				ingress:    createIngressObjectWithPath("testIngress", "test", testUrl),
 				namespace:  "test",
-				kubeClient: nil,
+				kubeClient: getTestKubeClient(),
 			},
-			want: "want",
+			want: "http://testurl.stackator.com/",
 		},
 	}
 	for _, tt := range tests {
@@ -78,4 +79,16 @@ func TestIngressWrapper_getURL(t *testing.T) {
 			}
 		})
 	}
+}
+
+func getTestKubeClient() kubernetes.Interface {
+	var kubeClient kubernetes.Interface
+	_, err := rest.InClusterConfig()
+	if err != nil {
+		kubeClient = GetClientOutOfCluster()
+	} else {
+		kubeClient = GetClient()
+	}
+
+	return kubeClient
 }


### PR DESCRIPTION
Use `path.Join` to join URLs instead of string concatenation to avoid duplicate slashes in URLs. 

Fixes https://github.com/stakater/IngressMonitorController/issues/57