### PR TITLE
Create annotation on Ingress to force https URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,14 @@ For the list of providers, there's a number of options that you need to specify.
 
 *Note:* Follow [this](https://github.com/stakater/IngressMonitorController/blob/master/docs/fetching-alert-contacts-from-uptime-robot.md) guide to see how to fetch `alertContacts` from UpTimeRobot
 
+#### Configuring through ingress annotations
+
+The following optional annotations allow you to set further configuration:
+
+| Annotation                          | Description                                                                                                                 |
+|-------------------------------------|-----------------------------------------------------------------------------------------------------------------------------|
+| `"monitor.stakater.com/forceHttps"` | If set to the string `"true"`, the monitor endpoint will use HTTPS, even if the Ingress manifest itself doesn't specify TLS |
+
 #### Deploying
 
 You can deploy the controller in the namespace you want to monitor by running the following kubectl commands:

--- a/README.md
+++ b/README.md
@@ -154,6 +154,25 @@ PRs are welcome. In general, we follow the "fork-and-pull" Git workflow.
 
 NOTE: Be sure to merge the latest from "upstream" before making a pull request!
 
+### Running Tests Locally
+
+Tests require a Kubernetes instance to talk to with a `test` namespace created, and a config with a valid UptimeRobot `apiKey` and `alertContacts`. For example, on MacOS with Homebrew and Minikube, you could accomplish this like
+
+```bash
+# install dependencies
+$ brew install glide
+$ cd src
+$ glide update
+
+# while still in the ./src folder, configure test setup
+$ export CONFIG_FILE_PATH=./test-config.yaml # update the apikey and alertContacts in this file
+$ minikube start
+$ kubectl create namespace test
+
+# run tests from inside the ./src folder
+$ go test
+```
+
 ## Changelog
 
 View our closed [Pull Requests](https://github.com/stakater/IngressMonitorController/pulls?q=is%3Apr+is%3Aclosed).

--- a/src/ingress-wrapper.go
+++ b/src/ingress-wrapper.go
@@ -11,6 +11,10 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
+const (
+	IngressForceHTTPSAnnotation = "monitor.stakater.com/forceHttps"
+)
+
 type IngressWrapper struct {
 	ingress    *v1beta1.Ingress
 	namespace  string
@@ -27,6 +31,14 @@ func (iw *IngressWrapper) supportsTLS() bool {
 func (iw *IngressWrapper) tryGetTLSHost() (string, bool) {
 	if iw.supportsTLS() {
 		return "https://" + iw.ingress.Spec.TLS[0].Hosts[0], true
+	}
+
+	annotations := iw.ingress.GetAnnotations()
+	if value, ok := annotations[IngressForceHTTPSAnnotation]; ok {
+		if value == "true" {
+			// Annotation exists and is enabled
+			return "https://" + iw.ingress.Spec.Rules[0].Host, true
+		}
 	}
 
 	return "", false

--- a/src/ingress-wrapper_test.go
+++ b/src/ingress-wrapper_test.go
@@ -27,6 +27,13 @@ func createIngressObjectWithPath(ingressName string, namespace string, url strin
 	return ingress
 }
 
+func createIngressObjectWithAnnotations(ingressName string, namespace string, url string, annotations map[string]string) *v1beta1.Ingress {
+	ingress := createIngressObject(ingressName, namespace, url)
+	ingress.ObjectMeta.SetAnnotations(annotations)
+
+	return ingress
+}
+
 func TestIngressWrapper_getURL(t *testing.T) {
 	type fields struct {
 		ingress    *v1beta1.Ingress
@@ -60,6 +67,24 @@ func TestIngressWrapper_getURL(t *testing.T) {
 			name: "TestGetUrlWithNoPath",
 			fields: fields{
 				ingress:    createIngressObject("testIngress", "test", testUrl),
+				namespace:  "test",
+				kubeClient: getTestKubeClient(),
+			},
+			want: "http://testurl.stackator.com/",
+		},
+		{
+			name: "TestGetUrlWithForceHTTPSAnnotation",
+			fields: fields{
+				ingress:    createIngressObjectWithAnnotations("testIngress", "test", testUrl, map[string]string{"monitor.stakater.com/forceHttps": "true"}),
+				namespace:  "test",
+				kubeClient: getTestKubeClient(),
+			},
+			want: "https://testurl.stackator.com/",
+		},
+		{
+			name: "TestGetUrlWithForceHTTPSAnnotationOff",
+			fields: fields{
+				ingress:    createIngressObjectWithAnnotations("testIngress", "test", testUrl, map[string]string{"monitor.stakater.com/forceHttps": "false"}),
 				namespace:  "test",
 				kubeClient: getTestKubeClient(),
 			},


### PR DESCRIPTION
As mentioned in #61, this implements an annotation that grants per-ingress control about the protocol for the URL in the ingress.

I also included the steps I had to take to start running tests locally. 

The IngressWrapper tests were passing locally with these changes.

```
go test -v ./src -run IngressWrapper
=== RUN   TestIngressWrapper_getURL
=== RUN   TestIngressWrapper_getURL/TestGetUrlWithEmptyPath
=== RUN   TestIngressWrapper_getURL/TestGetUrlWithHelloPath
=== RUN   TestIngressWrapper_getURL/TestGetUrlWithNoPath
=== RUN   TestIngressWrapper_getURL/TestGetUrlWithForceHTTPSAnnotation
=== RUN   TestIngressWrapper_getURL/TestGetUrlWithForceHTTPSAnnotationOff
--- PASS: TestIngressWrapper_getURL (0.08s)
    --- PASS: TestIngressWrapper_getURL/TestGetUrlWithEmptyPath (0.00s)
    --- PASS: TestIngressWrapper_getURL/TestGetUrlWithHelloPath (0.00s)
    --- PASS: TestIngressWrapper_getURL/TestGetUrlWithNoPath (0.00s)
    --- PASS: TestIngressWrapper_getURL/TestGetUrlWithForceHTTPSAnnotation (0.00s)
    --- PASS: TestIngressWrapper_getURL/TestGetUrlWithForceHTTPSAnnotationOff (0.00s)
PASS
ok  	_/Users/dgempesaw/opt/IngressMonitorController/src	0.100s
```

Cheers!

edit: rebasing on top of 1.0.15 as of 6/19