### PR TITLE
Create annotation for explicitly defining healthcheck path 

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,10 @@ For the list of providers, there's a number of options that you need to specify.
 
 The following optional annotations allow you to set further configuration:
 
-| Annotation                          | Description                                                                                                                 |
-|-------------------------------------|-----------------------------------------------------------------------------------------------------------------------------|
-| `"monitor.stakater.com/forceHttps"` | If set to the string `"true"`, the monitor endpoint will use HTTPS, even if the Ingress manifest itself doesn't specify TLS |
+| Annotation                            | Description                                                                                                                 |
+|---------------------------------------|-----------------------------------------------------------------------------------------------------------------------------|
+| `"monitor.stakater.com/forceHttps"`   | If set to the string `"true"`, the monitor endpoint will use HTTPS, even if the Ingress manifest itself doesn't specify TLS |
+| `"monitor.stakater.com/overridePath"` | Set this annotation to define the healthcheck path for this monitor, overriding the controller's default logic              |
 
 #### Deploying
 

--- a/pkg/kube/wrappers/ingress-wrapper_test.go
+++ b/pkg/kube/wrappers/ingress-wrapper_test.go
@@ -92,6 +92,15 @@ func TestIngressWrapper_getURL(t *testing.T) {
 			},
 			want: "http://testurl.stackator.com/",
 		},
+		{
+			name: "TestGetUrlWithOverridePathAnnotation",
+			fields: fields{
+				ingress:    createIngressObjectWithAnnotations("testIngress", "test", testUrl, map[string]string{"monitor.stakater.com/overridePath": "/overriden-path"}),
+				namespace:  "test",
+				kubeClient: getTestKubeClient(),
+			},
+			want: "http://testurl.stackator.com/overriden-path",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
As mentioned in #61, this adds an annotation on the Ingress that the controller will use to set the healthcheck path. If unset, the behavior is unchanged. Fixes #61.

I've created this on top of my commits from #62, so I don't think they'll merge cleanly on to master until #62 is merged. I'm happy to rebase either this PR or #62 as needed :)

edit: rebasing on top of 1.0.15 as of 6/19
