### PR TITLE
Add annotation for custom request header on Pingdom

### DIFF
--- a/docs/pingdom-configuration.md
+++ b/docs/pingdom-configuration.md
@@ -19,3 +19,4 @@ Currently additional pingdom configurations can be added through a set of annota
 | pingdom.monitor.stakater.com/send-notification-when-down | How many failed check attempts before notifying  |
 | pingdom.monitor.stakater.com/paused                      | Set to "true" to pause checks                    |
 | pingdom.monitor.stakater.com/notify-when-back-up         | Set to "false" to disable recovery notifications |
+| pingdom.monitor.stakater.com/request-headers             | Custom pingdom header (e.g {"Accept"="application/json"}) |

--- a/pkg/monitors/pingdom/pingdom-monitor.go
+++ b/pkg/monitors/pingdom/pingdom-monitor.go
@@ -18,6 +18,7 @@ const (
 	PingdomSendNotificationWhenDownAnnotation = "pingdom.monitor.stakater.com/send-notification-when-down"
 	PingdomPausedAnnotation                   = "pingdom.monitor.stakater.com/paused"
 	PingdomNotifyWhenBackUpAnnotation         = "pingdom.monitor.stakater.com/notify-when-back-up"
+	PingdomRequestHeadersAnnotation           = "pingdom.monitor.stakater.com/request-headers"
 )
 
 // PingdomMonitorService interfaces with MonitorService
@@ -180,6 +181,13 @@ func (service *PingdomMonitorService) addAnnotationConfigToHttpCheck(httpCheck *
 		}
 	} else {
 		httpCheck.SendNotificationWhenDown = 3
+	}
+
+	if value, ok := annotations[PingdomRequestHeadersAnnotation]; ok {
+		httpCheck.RequestHeaders = make(map[string]string)
+		for k, v := range value.(map[string]interface{}) {
+			httpCheck.RequestHeaders[k] = v.(string)
+		}
 	}
 
 }


### PR DESCRIPTION
Custom HTTP headers for Pingdom. 

It should be a hash with pairs, like { "header_name" = "header_content" }.

With Kubernetes ingress, this would ideally look like:

```
pingdom.monitor.stakater.com/request-headers: "{"Accept"="application/json"}"
```