### PR TITLE
Add support for integrations in Pingdom

### DIFF
--- a/configs/testConfigs/test-config-pingdom.yaml
+++ b/configs/testConfigs/test-config-pingdom.yaml
@@ -1,4 +1,4 @@
-providers: 
+providers:
   - name: PingdomMulti
     apiURL: "https://api.pingdom.com/v2/"
     apiKey: "657a68d9ashdyasjdklkskuasd"
@@ -6,4 +6,5 @@ providers:
     password: "SuperSecret"
     accountEmail: "multi@test.com"
     alertContacts: "0544483_0_0-2628365_0_0-2633263_0_0"
+    alertIntegrations: "91166,10924"
 enableMonitorDeletion: true

--- a/docs/pingdom-configuration.md
+++ b/docs/pingdom-configuration.md
@@ -16,9 +16,10 @@ in the [Configuration section of the README](../README.md#configuration):
 The following optional property can be included for Pingdom accounts which require multi-user authentication.
 More information can be found [Here](https://www.pingdom.com/api/2.1/#multi-user+authentication)
 
-| Key          | Description                                              |
-|--------------|----------------------------------------------------------|
-| accountEmail | Email account for multi-user authentication with Pingdom |
+| Key               | Description                                              |
+|-------------------|----------------------------------------------------------|
+| accountEmail      | Email account for multi-user authentication with Pingdom |
+| alertIntegrations | Comma separated list of integration ids                  |
 
 ## Advanced
 
@@ -32,8 +33,9 @@ Currently additional pingdom configurations can be added through a set of annota
 | pingdom.monitor.stakater.com/notify-when-back-up         | Set to "false" to disable recovery notifications |
 | pingdom.monitor.stakater.com/request-headers             | Custom pingdom request headers (e.g. {"Accept"="application/json"}) |
 | pingdom.monitor.stakater.com/basic-auth-user             | Required for basic-authentication checks - [see below](#basic-auth-checks) |
-| pingdom.monitor.stakater.com/should-contain              | Set to text string that has to be present in the HTML code of the page (configures "Should contain")|
-| pingdom.monitor.stakater.com/tags                        | Comma separated set of tags to apply to check (e.g. "testing,aws")|
+| pingdom.monitor.stakater.com/should-contain              | Set to text string that has to be present in the HTML code of the page (configures "Should contain") |
+| pingdom.monitor.stakater.com/tags                        | Comma separated set of tags to apply to check (e.g. "testing,aws") |
+| pingdom.monitor.stakater.com/alert-integrations                | Comma separated set list of integrations ids (e.g. "91166,12168") |
 
 ### Basic Auth checks
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -15,13 +15,14 @@ type Config struct {
 }
 
 type Provider struct {
-	Name          string `yaml:"name"`
-	ApiKey        string `yaml:"apiKey"`
-	ApiURL        string `yaml:"apiURL"`
-	AlertContacts string `yaml:"alertContacts"`
-	Username      string `yaml:"username"`
-	Password      string `yaml:"password"`
-	AccountEmail  string `yaml:"accountEmail"`
+	Name              string `yaml:"name"`
+	ApiKey            string `yaml:"apiKey"`
+	ApiURL            string `yaml:"apiURL"`
+	AlertContacts     string `yaml:"alertContacts"`
+	AlertIntegrations string `yaml:"alertIntegrations"`
+	Username          string `yaml:"username"`
+	Password          string `yaml:"password"`
+	AccountEmail      string `yaml:"accountEmail"`
 }
 
 func ReadConfig(filePath string) Config {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -11,6 +11,7 @@ const (
 	correctTestAPIKey                = "657a68d9ashdyasjdklkskuasd"
 	correctTestAPIURL                = "https://api.uptimerobot.com/v2/"
 	correctTestAlertContacts         = "0544483_0_0-2628365_0_0-2633263_0_0"
+	correctTestAlertIntegrations     = "91166,10924"
 	correctTestEnableMonitorDeletion = true
 
 	configFilePathPingdom          = "../../configs/testConfigs/test-config-pingdom.yaml"
@@ -28,7 +29,7 @@ const (
 )
 
 func TestConfigWithCorrectValues(t *testing.T) {
-	correctConfig := Config{Providers: []Provider{Provider{Name: correctTestConfigName, ApiKey: correctTestAPIKey, ApiURL: correctTestAPIURL, AlertContacts: correctTestAlertContacts}}, EnableMonitorDeletion: correctTestEnableMonitorDeletion}
+	correctConfig := Config{Providers: []Provider{Provider{Name: correctTestConfigName, ApiKey: correctTestAPIKey, ApiURL: correctTestAPIURL, AlertContacts: correctTestAlertContacts, AlertIntegrations: correctTestAlertIntegrations}}, EnableMonitorDeletion: correctTestEnableMonitorDeletion}
 	config := ReadConfig(configFilePath)
 
 	if !reflect.DeepEqual(config, correctConfig) {

--- a/pkg/monitors/pingdom/pingdom-monitor.go
+++ b/pkg/monitors/pingdom/pingdom-monitor.go
@@ -43,6 +43,7 @@ func (service *PingdomMonitorService) Setup(p config.Provider) {
 	service.apiKey = p.ApiKey
 	service.url = p.ApiURL
 	service.alertContacts = p.AlertContacts
+	service.alertIntegrations = p.AlertIntegrations
 	service.username = p.Username
 	service.password = p.Password
 


### PR DESCRIPTION
Closes #158.

Added the possibility to set integrationIds on Pingdom checks: https://www.pingdom.com/api/2.1/#MethodCreate+New+Check.

This can be done on operator level and on annotation level. Annotations will overwrite operator settings though. Not sure this is a good idea. Happy for feedback.