### PR TITLE
Remove route port

### DIFF
--- a/pkg/kube/wrappers/routeWrapper.go
+++ b/pkg/kube/wrappers/routeWrapper.go
@@ -45,13 +45,6 @@ func (rw *RouteWrapper) getHost() string {
 	return "http://" + rw.Route.Spec.Host
 }
 
-func (rw *RouteWrapper) getRouteSubPathWithPort() string {
-	port := rw.getRoutePort()
-	subPath := rw.getRouteSubPath()
-
-	return port + subPath
-}
-
 func (rw *RouteWrapper) getRoutePort() string {
 	if rw.Route.Spec.Port != nil && rw.Route.Spec.Port.TargetPort.String() != "" {
 		return rw.Route.Spec.Port.TargetPort.String()
@@ -127,8 +120,8 @@ func (rw *RouteWrapper) GetURL() string {
 	if value, ok := annotations[constants.OverridePathAnnotation]; ok {
 		u.Path = value
 	} else {
-		// Append port + path
-		u.Path = path.Join(u.Path, rw.getRouteSubPathWithPort())
+		// Append port
+		u.Path = path.Join(u.Path, rw.getRouteSubPath())
 
 		// Find pod by backtracking route -> service -> pod
 		healthEndpoint, exists := rw.tryGetHealthEndpointFromRoute()

--- a/pkg/kube/wrappers/routeWrapper.go
+++ b/pkg/kube/wrappers/routeWrapper.go
@@ -120,7 +120,7 @@ func (rw *RouteWrapper) GetURL() string {
 	if value, ok := annotations[constants.OverridePathAnnotation]; ok {
 		u.Path = value
 	} else {
-		// Append port
+		// Append subpath
 		u.Path = path.Join(u.Path, rw.getRouteSubPath())
 
 		// Find pod by backtracking route -> service -> pod


### PR DESCRIPTION
The Route schema states that you can only provide a `targetPort` under `spec.port` and since it will only be used by the route to lookup the service port, we don't need to find the port for the route as the default ones are 443 and 80 which are handled by default