### PR TITLE
Uptimerobot alertcontacts

### DIFF
--- a/docs/uptimerobot-configuration.md
+++ b/docs/uptimerobot-configuration.md
@@ -37,6 +37,7 @@ Additional uptime robot configurations can be added through a set of annotations
 
 |                        Annotation                    |                    Description                               |
 |:----------------------------------------------------:|:------------------------------------------------------------:|
+| uptimerobot.monitor.stakater.com/alert-contacts       | The uptimerobot alertContacts to be associated with this monitor. Overrides the value of `alertContacts` from the Controller's ConfigMap. See [Fetching alert contacts from UpTime Robot](https://github.com/stakater/IngressMonitorController/blob/master/docs/uptimerobot-configuration.md) |
 | uptimerobot.monitor.stakater.com/interval            | The uptimerobot check interval in seconds                    |
 | uptimerobot.monitor.stakater.com/status-pages        | The uptimerobot public status page ID to add this monitor to |
 | uptimerobot.monitor.stakater.com/maintenance-windows | Add a maintenance windows to this check (Pro Plan only)      |

--- a/pkg/monitors/uptimerobot/uptime-mappers.go
+++ b/pkg/monitors/uptimerobot/uptime-mappers.go
@@ -2,6 +2,7 @@ package uptimerobot
 
 import (
 	"strconv"
+	"strings"
 
 	"github.com/stakater/IngressMonitorController/pkg/models"
 	"github.com/stakater/IngressMonitorController/pkg/util"
@@ -17,6 +18,16 @@ func UptimeMonitorMonitorToBaseMonitorMapper(uptimeMonitor UptimeMonitorMonitor)
 	var annotations = map[string]string{
 		"uptimerobot.monitor.stakater.com/interval": strconv.Itoa(uptimeMonitor.Interval),
 	}
+
+	alertContacts := make([]string,0)
+	if uptimeMonitor.AlertContacts != nil {
+		for _, alertContact := range uptimeMonitor.AlertContacts {
+			contact := alertContact.ID + "_" + strconv.Itoa(alertContact.threshold) + "_" + strconv.Itoa(alertContact.recurrence)
+			alertContacts = append(alertContacts, contact)
+		}
+		annotations["uptimerobot.monitor.stakater.com/alert-contacts"] = strings.Join(alertContacts,"-")
+	}
+
 	m.Annotations = annotations
 
 	return &m

--- a/pkg/monitors/uptimerobot/uptime-mappers.go
+++ b/pkg/monitors/uptimerobot/uptime-mappers.go
@@ -22,7 +22,7 @@ func UptimeMonitorMonitorToBaseMonitorMapper(uptimeMonitor UptimeMonitorMonitor)
 	alertContacts := make([]string,0)
 	if uptimeMonitor.AlertContacts != nil {
 		for _, alertContact := range uptimeMonitor.AlertContacts {
-			contact := alertContact.ID + "_" + strconv.Itoa(alertContact.threshold) + "_" + strconv.Itoa(alertContact.recurrence)
+			contact := alertContact.ID + "_" + strconv.Itoa(alertContact.Threshold) + "_" + strconv.Itoa(alertContact.Recurrence)
 			alertContacts = append(alertContacts, contact)
 		}
 		annotations["uptimerobot.monitor.stakater.com/alert-contacts"] = strings.Join(alertContacts,"-")

--- a/pkg/monitors/uptimerobot/uptime-monitor.go
+++ b/pkg/monitors/uptimerobot/uptime-monitor.go
@@ -35,7 +35,7 @@ func (monitor *UpTimeMonitorService) GetByName(name string) (*models.Monitor, er
 
 	client := http.CreateHttpClient(monitor.url + action)
 
-	body := "api_key=" + monitor.apiKey + "&format=json&logs=1" + "&search=" + name
+	body := "api_key=" + monitor.apiKey + "&format=json&logs=1&alert_contacts=1&search=" + name
 
 	response := client.PostUrlEncodedFormBody(body)
 

--- a/pkg/monitors/uptimerobot/uptime-monitor.go
+++ b/pkg/monitors/uptimerobot/uptime-monitor.go
@@ -114,7 +114,13 @@ func (monitor *UpTimeMonitorService) Add(m models.Monitor) {
 
 	client := http.CreateHttpClient(monitor.url + action)
 
-	body := "api_key=" + monitor.apiKey + "&format=json&url=" + url.QueryEscape(m.URL) + "&friendly_name=" + url.QueryEscape(m.Name) + "&alert_contacts=" + monitor.alertContacts
+	body := "api_key=" + monitor.apiKey + "&format=json&url=" + url.QueryEscape(m.URL) + "&friendly_name=" + url.QueryEscape(m.Name)
+
+	if val, ok := m.Annotations["uptimerobot.monitor.stakater.com/alert-contacts"]; ok {
+		body += "&alert_contacts=" + val
+	} else {
+		body += "&alert_contacts=" + monitor.alertContacts
+	}
 
 	if val, ok := m.Annotations["uptimerobot.monitor.stakater.com/interval"]; ok {
 		body += "&interval=" + val
@@ -174,7 +180,13 @@ func (monitor *UpTimeMonitorService) Update(m models.Monitor) {
 
 	client := http.CreateHttpClient(monitor.url + action)
 
-	body := "api_key=" + monitor.apiKey + "&format=json&id=" + m.ID + "&friendly_name=" + m.Name + "&url=" + m.URL + "&alert_contacts=" + monitor.alertContacts
+	body := "api_key=" + monitor.apiKey + "&format=json&url=" + url.QueryEscape(m.URL) + "&friendly_name=" + url.QueryEscape(m.Name)
+	
+	if val, ok := m.Annotations["uptimerobot.monitor.stakater.com/alert-contacts"]; ok {
+		body += "&alert_contacts=" + val
+	} else {
+		body += "&alert_contacts=" + monitor.alertContacts
+	}
 
 	if val, ok := m.Annotations["uptimerobot.monitor.stakater.com/interval"]; ok {
 		body += "&interval=" + val

--- a/pkg/monitors/uptimerobot/uptime-monitor.go
+++ b/pkg/monitors/uptimerobot/uptime-monitor.go
@@ -180,8 +180,8 @@ func (monitor *UpTimeMonitorService) Update(m models.Monitor) {
 
 	client := http.CreateHttpClient(monitor.url + action)
 
-	body := "api_key=" + monitor.apiKey + "&format=json&url=" + url.QueryEscape(m.URL) + "&friendly_name=" + url.QueryEscape(m.Name)
-	
+	body := "api_key=" + monitor.apiKey + "&format=json&id=" + m.ID + "&friendly_name=" + m.Name + "&url=" + m.URL
+
 	if val, ok := m.Annotations["uptimerobot.monitor.stakater.com/alert-contacts"]; ok {
 		body += "&alert_contacts=" + val
 	} else {

--- a/pkg/monitors/uptimerobot/uptime-monitor_test.go
+++ b/pkg/monitors/uptimerobot/uptime-monitor_test.go
@@ -361,7 +361,7 @@ func TestAddMonitorWithAlertContactsAnnotations(t *testing.T) {
 	service.Setup(*provider)
 
 	var annotations = map[string]string{
-		"uptimerobot.monitor.stakater.com/alert-contacts": "123456_0_0",
+		"uptimerobot.monitor.stakater.com/alert-contacts": "2628365_0_0",
 	}
 
 	m := models.Monitor{Name: "google-test", URL: "https://google.com", Annotations: annotations}
@@ -378,8 +378,8 @@ func TestAddMonitorWithAlertContactsAnnotations(t *testing.T) {
 	if mRes.URL != m.URL {
 		t.Error("The URL is incorrect, expected: " + m.URL + ", but was: " + mRes.URL)
 	}
-	if "2938709_0_0" != mRes.Annotations["uptimerobot.monitor.stakater.com/alert-contacts"] {
-		t.Error("The alert-contacts is incorrect, expected: 2938709_0_0, but was: " + mRes.Annotations["uptimerobot.monitor.stakater.com/alert-contacts"])
+	if "2628365_0_0" != mRes.Annotations["uptimerobot.monitor.stakater.com/alert-contacts"] {
+		t.Error("The alert-contacts is incorrect, expected: 2628365_0_0, but was: " + mRes.Annotations["uptimerobot.monitor.stakater.com/alert-contacts"])
 	}
 	service.Remove(*mRes)
 }

--- a/pkg/monitors/uptimerobot/uptime-monitor_test.go
+++ b/pkg/monitors/uptimerobot/uptime-monitor_test.go
@@ -352,3 +352,34 @@ func TestAddMonitorWithIncorrectValues(t *testing.T) {
 		t.Error("Monitor should not be added")
 	}
 }
+
+func TestAddMonitorWithAlertContactsAnnotations(t *testing.T) {
+	config := config.GetControllerConfig()
+
+	service := UpTimeMonitorService{}
+	provider := util.GetProviderWithName(config, "UptimeRobot")
+	service.Setup(*provider)
+
+	var annotations = map[string]string{
+		"uptimerobot.monitor.stakater.com/alert-contacts": "123456_0_0",
+	}
+
+	m := models.Monitor{Name: "google-test", URL: "https://google.com", Annotations: annotations}
+	service.Add(m)
+
+	mRes, err := service.GetByName("google-test")
+
+	if err != nil {
+		t.Error("Error: " + err.Error())
+	}
+	if mRes.Name != m.Name {
+		t.Error("The name is incorrect, expected: " + m.Name + ", but was: " + mRes.Name)
+	}
+	if mRes.URL != m.URL {
+		t.Error("The URL is incorrect, expected: " + m.URL + ", but was: " + mRes.URL)
+	}
+	if "2938709_0_0" != mRes.Annotations["uptimerobot.monitor.stakater.com/alert-contacts"] {
+		t.Error("The alert-contacts is incorrect, expected: 2938709_0_0, but was: " + mRes.Annotations["uptimerobot.monitor.stakater.com/alert-contacts"])
+	}
+	service.Remove(*mRes)
+}

--- a/pkg/monitors/uptimerobot/uptime-responses.go
+++ b/pkg/monitors/uptimerobot/uptime-responses.go
@@ -32,8 +32,8 @@ type UptimeMonitorMonitor struct {
 
 type UptimeMonitorAlertContacts struct {
 	ID         string `json:"id"`
-	threshold  int    `json:"threshold"`
-	recurrence int    `json:"recurrence"`
+	Threshold  int    `json:"threshold"`
+	Recurrence int    `json:"recurrence"`
 }
 
 type UptimeMonitorLogs struct {

--- a/pkg/monitors/uptimerobot/uptime-responses.go
+++ b/pkg/monitors/uptimerobot/uptime-responses.go
@@ -13,20 +13,27 @@ type UptimeMonitorPagination struct {
 }
 
 type UptimeMonitorMonitor struct {
-	ID             int                 `json:"id"`
-	FriendlyName   string              `json:"friendly_name"`
-	URL            string              `json:"url"`
-	Type           int                 `json:"type"`
-	SubType        string              `json:"sub_type"`
-	KeywordType    int                 `json:"keyword_type"`
-	KeywordValue   string              `json:"keyword_value"`
-	HTTPUsername   string              `json:"http_username"`
-	HTTPPassword   string              `json:"http_password"`
-	Port           string              `json:"port"`
-	Interval       int                 `json:"interval"`
-	Status         int                 `json:"status"`
-	CreateDatetime int                 `json:"create_datetime"`
-	Logs           []UptimeMonitorLogs `json:"logs"`
+	ID             int                          `json:"id"`
+	FriendlyName   string                       `json:"friendly_name"`
+	URL            string                       `json:"url"`
+	Type           int                          `json:"type"`
+	SubType        string                       `json:"sub_type"`
+	KeywordType    int                          `json:"keyword_type"`
+	KeywordValue   string                       `json:"keyword_value"`
+	HTTPUsername   string                       `json:"http_username"`
+	HTTPPassword   string                       `json:"http_password"`
+	Port           string                       `json:"port"`
+	Interval       int                          `json:"interval"`
+	Status         int                          `json:"status"`
+	CreateDatetime int                          `json:"create_datetime"`
+	Logs           []UptimeMonitorLogs          `json:"logs"`
+	AlertContacts  []UptimeMonitorAlertContacts `json:"alert_contacts"`
+}
+
+type UptimeMonitorAlertContacts struct {
+	ID         string `json:"id"`
+	threshold  int    `json:"threshold"`
+	recurrence int    `json:"recurrence"`
 }
 
 type UptimeMonitorLogs struct {


### PR DESCRIPTION
This Pull Request adds the ability to override the Alert Contact of a monitor in UptimeRobot via an annotation on the ingress/route, but falling back to the default defined in the controller's config if not present in an annotation on the route.