### PR TITLE
Remove regex capture group from path

### DIFF
--- a/deploy/olm-catalog/ingressmonitorcontroller/2.0.4/ingressmonitorcontroller.v2.0.4.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ingressmonitorcontroller/2.0.4/ingressmonitorcontroller.v2.0.4.clusterserviceversion.yaml
@@ -1,0 +1,144 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: '[]'
+    capabilities: Basic Install
+  name: ingressmonitorcontroller.v2.0.4
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: EndpointMonitor is the Schema for the endpointmonitors API
+      kind: EndpointMonitor
+      name: endpointmonitors.endpointmonitor.stakater.com
+      version: v1alpha1
+  description: Placeholder description
+  displayName: Ingress Monitor Controller
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - ""
+          - extensions
+          - route.openshift.io
+          resources:
+          - ingresses
+          - routes
+          - secrets
+          verbs:
+          - list
+          - get
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          - services
+          - configmaps
+          - services/finalizers
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          - replicasets
+          - statefulsets
+          verbs:
+          - '*'
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - get
+          - create
+          - list
+        - apiGroups:
+          - apps
+          resourceNames:
+          - ingressmonitorcontroller
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - get
+        - apiGroups:
+          - endpointmonitor.stakater.com
+          resources:
+          - '*'
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        serviceAccountName: ingressmonitorcontroller
+      deployments:
+      - name: ingressmonitorcontroller
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: ingressmonitorcontroller
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                name: ingressmonitorcontroller
+            spec:
+              containers:
+              - command:
+                - IngressMonitorController
+                env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: ingressmonitorcontroller
+                - name: CONFIG_SECRET_NAME
+                  value: imc-config
+                - name: LOG_LEVEL
+                  value: info
+                - name: LOG_FORMAT
+                  value: text
+                image: stakater/ingressmonitorcontroller:v2.0.4
+                imagePullPolicy: Always
+                name: ingressmonitorcontroller
+                resources: {}
+              serviceAccountName: ingressmonitorcontroller
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  maturity: alpha
+  provider: {}
+  replaces: ingressmonitorcontroller.v0.0.0
+  version: 2.0.4

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -15,9 +15,9 @@ spec:
       serviceAccountName: ingressmonitorcontroller
       containers:
         - name: ingressmonitorcontroller
-          image: stakater/ingressmonitorcontroller:v2.0.2
+          image: stakater/ingressmonitorcontroller:v2.0.4
           command:
-          - IngressMonitorController
+            - IngressMonitorController
           imagePullPolicy: Always
           env:
             - name: WATCH_NAMESPACE
@@ -36,4 +36,3 @@ spec:
               value: info
             - name: LOG_FORMAT
               value: text
-

--- a/pkg/kube/wrappers/ingress-wrapper.go
+++ b/pkg/kube/wrappers/ingress-wrapper.go
@@ -60,11 +60,15 @@ func (iw *IngressWrapper) getIngressSubPath() string {
 	rule := iw.Ingress.Spec.Rules[0]
 	if rule.HTTP != nil {
 		if rule.HTTP.Paths != nil && len(rule.HTTP.Paths) > 0 {
-			if strings.ContainsAny(rule.HTTP.Paths[0].Path, "*") {
-				return strings.TrimRight(rule.HTTP.Paths[0].Path, "*")
-			} else {
-				return rule.HTTP.Paths[0].Path
-			}
+			path := rule.HTTP.Paths[0].Path
+
+			// Remove * from path if exists
+			path = strings.TrimRight(path, "*")
+			// Remove regex caputure group from path if exists
+			parsed := strings.Split(path, "(")
+			path = parsed[0]
+
+			return path
 		}
 	}
 	return ""

--- a/pkg/kube/wrappers/ingress-wrapper_test.go
+++ b/pkg/kube/wrappers/ingress-wrapper_test.go
@@ -82,6 +82,13 @@ func TestIngressWrapper_getURL(t *testing.T) {
 			},
 			want: "http://testurl.stackator.com/",
 		}, {
+			name: "TestGetUrlWithRegexCaptureGroupInPath",
+			fields: fields{
+				ingress: createIngressObjectWithPath("testIngress", "test", testUrl, "/api(/|$)(.*)"),
+				Client:  fakekubeclient.NewFakeClient(),
+			},
+			want: "http://testurl.stackator.com/api",
+		}, {
 			name: "TestGetUrlWithTLS",
 			fields: fields{
 				ingress: createIngressObjectWithTLS("testIngress", "test", testUrl, "customtls.stackator.com"),


### PR DESCRIPTION
Removes regex capture groups from path when creating a monitor. 
Required if ingresses have a regex capture group to support rewrite-target for nginx-ingress

https://kubernetes.github.io/ingress-nginx/examples/rewrite/#rewrite-target