### PR TITLE
[Version 1] Remove regex capture group from path

### DIFF
--- a/pkg/kube/wrappers/ingress-wrapper.go
+++ b/pkg/kube/wrappers/ingress-wrapper.go
@@ -58,11 +58,15 @@ func (iw *IngressWrapper) getIngressSubPath() string {
 	rule := iw.Ingress.Spec.Rules[0]
 	if rule.HTTP != nil {
 		if rule.HTTP.Paths != nil && len(rule.HTTP.Paths) > 0 {
-			if strings.ContainsAny(rule.HTTP.Paths[0].Path, "*") {
-				return strings.TrimRight(rule.HTTP.Paths[0].Path, "*")
-			} else {
-				return rule.HTTP.Paths[0].Path
-			}
+			path := rule.HTTP.Paths[0].Path
+
+			// Remove * from path if exists
+			path = strings.TrimRight(path, "*")
+			// Remove regex caputure group from path if exists
+			parsed := strings.Split(path, "(")
+			path = parsed[0]
+
+			return path
 		}
 	}
 	return ""

--- a/pkg/kube/wrappers/ingress-wrapper_test.go
+++ b/pkg/kube/wrappers/ingress-wrapper_test.go
@@ -37,15 +37,15 @@ func createIngressObjectWithAnnotations(ingressName string, namespace string, ur
 }
 
 func createIngressObjectWithTLS(ingressName string, namespace string, url string, tlsHostname string) *v1beta1.Ingress {
-  ingress := util.CreateIngressObject(ingressName, namespace, url)
-  ingress.Spec.TLS = []v1beta1.IngressTLS{
-    v1beta1.IngressTLS{
-      Hosts: []string{
-        tlsHostname,
-      },
-    },
-  }
-  return ingress
+	ingress := util.CreateIngressObject(ingressName, namespace, url)
+	ingress.Spec.TLS = []v1beta1.IngressTLS{
+		v1beta1.IngressTLS{
+			Hosts: []string{
+				tlsHostname,
+			},
+		},
+	}
+	return ingress
 }
 
 func TestIngressWrapper_getURL(t *testing.T) {
@@ -121,6 +121,14 @@ func TestIngressWrapper_getURL(t *testing.T) {
 			},
 			want: "http://testurl.stackator.com/",
 		}, {
+			name: "TestGetUrlWithRegexCaptureGroupInPath",
+			fields: fields{
+				ingress:    createIngressObjectWithPath("testIngress", "test", testUrl, "/api(/|$)(.*)"),
+				namespace:  "test",
+				kubeClient: getTestKubeClient(),
+			},
+			want: "http://testurl.stackator.com/api",
+		}, {
 			name: "TestGetUrlWithTLS",
 			fields: fields{
 				ingress:    createIngressObjectWithTLS("testIngress", "test", testUrl, "customtls.stackator.com"),
@@ -137,7 +145,6 @@ func TestIngressWrapper_getURL(t *testing.T) {
 			},
 			want: "http://testurl.stackator.com",
 		},
-
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Removes regex capture groups from path when creating a monitor.
Required if ingresses have a regex capture group to support rewrite-target for nginx-ingress

https://kubernetes.github.io/ingress-nginx/examples/rewrite/#rewrite-target