### PR TITLE
kustomize deployment

### DIFF
--- a/deploy/kustomization.yaml
+++ b/deploy/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- crds/endpointmonitor.stakater.com_endpointmonitors_crd.yaml
+- operator.yaml
+- role.yaml
+- role_binding.yaml
+- service_account.yaml


### PR DESCRIPTION
### Kustomize for deployment

We use kustomize for our infrastructure, and we want to install operator without duplicate it to our repository. Previously we use yours helm chart and Helm Operator, but you don't support it yet for operator.

Is this ok for you to use Kustomize here?