### PR TITLE
deploy/role.yaml: add missing watch and list grants

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -15,6 +15,7 @@ rules:
   verbs:
   - list
   - get
+  - watch
 - apiGroups:
   - ""
   resources:
@@ -61,6 +62,8 @@ rules:
   - pods
   verbs:
   - get
+  - list
+  - watch
 - apiGroups:
   - endpointmonitor.stakater.com
   resources:


### PR DESCRIPTION
Without them controller is not able to watch Pods nor Ingress objects.

Closes #280.

Signed-off-by: Mateusz Gozdek <mgozdekof@gmail.com>