### PR TITLE
Uptime: add "tags" for monitor creation 

### DIFF
--- a/deploy/crds/endpointmonitor.stakater.com_endpointmonitors_crd.yaml
+++ b/deploy/crds/endpointmonitor.stakater.com_endpointmonitors_crd.yaml
@@ -183,6 +183,9 @@ spec:
                 locations:
                   description: Add different locations for the check
                   type: string
+                tags:
+                  description: Add different tags for the check
+                  type: string
               type: object
             uptimeRobotConfig:
               description: Configuration for UptimeRobot Monitor Provider

--- a/docs/uptime-configurations.md
+++ b/docs/uptime-configurations.md
@@ -29,4 +29,5 @@ spec:
     checkType: HTTP
     contacts: "133,132"
     locations: "sea,fr"
+    tags: "core" # ignored if not passed
 ```

--- a/pkg/apis/endpointmonitor/v1alpha1/endpointmonitor_types.go
+++ b/pkg/apis/endpointmonitor/v1alpha1/endpointmonitor_types.go
@@ -108,6 +108,10 @@ type UptimeConfig struct {
 	// Add different locations for the check
 	// +optional
 	Locations string `json:"locations,omitempty"`
+
+	// Add different tags for the check
+	// +optional
+	Tags string `json:"locations,omitempty"`
 }
 
 // UpdownConfig defines the configuration for Updown Monitor Provider

--- a/pkg/monitors/uptime/uptime-mappers.go
+++ b/pkg/monitors/uptime/uptime-mappers.go
@@ -20,6 +20,7 @@ func UptimeMonitorMonitorToBaseMonitorMapper(uptimeMonitor UptimeMonitorMonitor)
 	providerConfig.CheckType = uptimeMonitor.CheckType
 	providerConfig.Contacts = strings.Join(uptimeMonitor.ContactGroups, ",")
 	providerConfig.Locations = strings.Join(uptimeMonitor.Locations, ",")
+	providerConfig.Tags = strings.Join(uptimeMonitor.Tags, ",")
 
 	m.Config = &providerConfig
 	return &m

--- a/pkg/monitors/uptime/uptime-mappers_test.go
+++ b/pkg/monitors/uptime/uptime-mappers_test.go
@@ -56,7 +56,8 @@ func TestUptimeMonitorMonitorsToBaseMonitorsMapper(t *testing.T) {
 		MspInterval:   10,
 		CheckType:     "ICMP",
 		Locations:     []string{"US-Central"},
-		ContactGroups: []string{"Default"}}
+		ContactGroups: []string{"Default"},
+		Tags:          []string{"Core"}}
 
 	config1 := &endpointmonitorv1alpha1.UptimeConfig{
 		Interval:  5,
@@ -69,6 +70,7 @@ func TestUptimeMonitorMonitorsToBaseMonitorsMapper(t *testing.T) {
 		CheckType: "ICMP",
 		Locations: "US-Central",
 		Contacts:  "Default",
+		Tags:      "Core",
 	}
 
 	correctMonitors := []models.Monitor{

--- a/pkg/monitors/uptime/uptime-monitor.go
+++ b/pkg/monitors/uptime/uptime-monitor.go
@@ -211,5 +211,9 @@ func processProviderConfig(m models.Monitor) map[string]interface{} {
 		body["contact_groups"] = strings.Split("Default", ",") // use default use email as a contact
 	}
 
+	if providerConfig != nil && len(providerConfig.Tags) != 0 {
+		body["tags"] = strings.Split(providerConfig.Tags, ",")
+	}
+
 	return body
 }


### PR DESCRIPTION
Hi all,

We are working with uptime, and we need to be able to create checks together with tags. This is a simple change expanding the providerConfig. Let me know, if I need to make additional changes somewhere