### PR TITLE
Fix: Uptime API_LIMIT issue with due to unnecessary updates 

### DIFF
--- a/pkg/controller/endpointmonitor/endpointmonitor_updated.go
+++ b/pkg/controller/endpointmonitor/endpointmonitor_updated.go
@@ -6,12 +6,10 @@ import (
 	"github.com/stakater/IngressMonitorController/pkg/models"
 	"github.com/stakater/IngressMonitorController/pkg/monitors"
 
-	log "github.com/sirupsen/logrus"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 func (r *ReconcileEndpointMonitor) handleUpdate(request reconcile.Request, instance *endpointmonitorv1alpha1.EndpointMonitor, monitor models.Monitor, monitorService monitors.MonitorServiceProxy) error {
-	log.Info("Updating Monitor: " + monitor.Name)
 
 	url, err := util.GetMonitorURL(r.client, instance)
 	if err != nil {


### PR DESCRIPTION
Summary: As per Uptime API documentation, Only 30 calls per minute are allowed, and post limit , all calls will be throttled. 

_[API Fair Use Limits](https://uptime.com/api/v1/docs/)
To ensure high performance and fair access of the API for all our customers, API calls are rate-limited to a maximum of 500 calls per hour and 30 calls per minute. There are no daily or monthly usage limits.`_

Currently, IMC is not comparing old/new monitor during resync and which leads to unnecessary update calls for every created monitor.

```go
func (monitor *UpTimeMonitorService) Equal(oldMonitor models.Monitor, newMonitor models.Monitor) bool {
	// TODO: Retrieve oldMonitor config and compare it here
	return false
}
```
In our case, we have around 50 monitors( eventually only 30 were created successfully rest all still pending due to uptime throttling, Error Message:

`{"messages":{"errors":true,"error_code":"API_RATE_LIMIT","error_message":"Sorry, your recent action hit the account API fair use limit and has been throttled. You may retry in 1061 seconds."}}"`

With this PR, I have updated the **Equal(*)** for uptime which would skip update for an existing monitor without any changes, also added respective tests.

