### PR TITLE
add tagging support for uptime http check

### DIFF
--- a/deploy/crds/endpointmonitor.stakater.com_endpointmonitors_crd.yaml
+++ b/deploy/crds/endpointmonitor.stakater.com_endpointmonitors_crd.yaml
@@ -183,6 +183,9 @@ spec:
                 locations:
                   description: Add different locations for the check
                   type: string
+                tags:
+                  description: Add one or more tags for the check separated by `,`
+                  type: string
               type: object
             uptimeRobotConfig:
               description: Configuration for UptimeRobot Monitor Provider

--- a/pkg/apis/endpointmonitor/v1alpha1/endpointmonitor_types.go
+++ b/pkg/apis/endpointmonitor/v1alpha1/endpointmonitor_types.go
@@ -108,6 +108,10 @@ type UptimeConfig struct {
 	// Add different locations for the check
 	// +optional
 	Locations string `json:"locations,omitempty"`
+
+	// Add one or more tags for the check separated by `,`
+	// +optional
+	Tags string `json:"tags,omitempty"`
 }
 
 // UpdownConfig defines the configuration for Updown Monitor Provider

--- a/pkg/monitors/uptime/uptime-mappers.go
+++ b/pkg/monitors/uptime/uptime-mappers.go
@@ -20,7 +20,7 @@ func UptimeMonitorMonitorToBaseMonitorMapper(uptimeMonitor UptimeMonitorMonitor)
 	providerConfig.CheckType = uptimeMonitor.CheckType
 	providerConfig.Contacts = strings.Join(uptimeMonitor.ContactGroups, ",")
 	providerConfig.Locations = strings.Join(uptimeMonitor.Locations, ",")
-
+	providerConfig.Tags = strings.Join(uptimeMonitor.Tags, ",")
 	m.Config = &providerConfig
 	return &m
 }

--- a/pkg/monitors/uptime/uptime-mappers_test.go
+++ b/pkg/monitors/uptime/uptime-mappers_test.go
@@ -48,7 +48,8 @@ func TestUptimeMonitorMonitorsToBaseMonitorsMapper(t *testing.T) {
 		MspInterval:   5,
 		CheckType:     "HTTP",
 		Locations:     []string{"US-Central"},
-		ContactGroups: []string{"Default"}}
+		ContactGroups: []string{"Default"},
+		Tags:          []string{"Core"}}
 	uptimeMonitorObject2 := UptimeMonitorMonitor{
 		Name:          "Test Monitor 2",
 		PK:            125,
@@ -56,19 +57,22 @@ func TestUptimeMonitorMonitorsToBaseMonitorsMapper(t *testing.T) {
 		MspInterval:   10,
 		CheckType:     "ICMP",
 		Locations:     []string{"US-Central"},
-		ContactGroups: []string{"Default"}}
+		ContactGroups: []string{"Default"},
+		Tags:          []string{"Shared"}}
 
 	config1 := &endpointmonitorv1alpha1.UptimeConfig{
 		Interval:  5,
 		CheckType: "HTTP",
 		Locations: "US-Central",
 		Contacts:  "Default",
+		Tags:      "Core",
 	}
 	config2 := &endpointmonitorv1alpha1.UptimeConfig{
 		Interval:  10,
 		CheckType: "ICMP",
 		Locations: "US-Central",
 		Contacts:  "Default",
+		Tags:      "Shared",
 	}
 
 	correctMonitors := []models.Monitor{

--- a/pkg/monitors/uptime/uptime-monitor.go
+++ b/pkg/monitors/uptime/uptime-monitor.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stakater/IngressMonitorController/pkg/config"
 	"github.com/stakater/IngressMonitorController/pkg/http"
 	"github.com/stakater/IngressMonitorController/pkg/models"
+	"github.com/stakater/IngressMonitorController/pkg/util"
 )
 
 type UpTimeMonitorService struct {
@@ -206,19 +207,21 @@ func processProviderConfig(m models.Monitor) map[string]interface{} {
 
 	// sorting locations which is useful during Equal method used in Update.
 	if providerConfig != nil && len(providerConfig.Locations) != 0 {
-		locations := strings.Split(providerConfig.Locations, ",")
-		sort.Strings(locations)
-		body["locations"] = locations
+		body["locations"] = util.SplitAndSort(providerConfig.Locations, ",")
 	} else {
 		locations := strings.Split("US-East,US-West,GBR", ",") // by default 3 lcoations for a check
 		sort.Strings(locations)
-		body["locations"] = locations
+		body["locations"] = util.SplitAndSort(providerConfig.Locations, ",")
 	}
 
 	if providerConfig != nil && len(providerConfig.Contacts) != 0 {
-		body["contact_groups"] = strings.Split(providerConfig.Contacts, ",")
+		body["contact_groups"] = util.SplitAndSort(providerConfig.Contacts, ",")
 	} else {
 		body["contact_groups"] = strings.Split("Default", ",") // use default use email as a contact
+	}
+
+	if providerConfig != nil && len(providerConfig.Tags) != 0 {
+		body["tags"] = util.SplitAndSort(providerConfig.Tags, ",")
 	}
 
 	return body

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1,7 +1,9 @@
 package util
 
 import (
+	"sort"
 	"strconv"
+	"strings"
 )
 
 func SliceAtoi(stringSlice []string) ([]int, error) {
@@ -45,4 +47,11 @@ func ContainsString(s []string, e string) bool {
 		}
 	}
 	return false
+}
+
+func SplitAndSort(s string, sep string) []string {
+
+	slice := strings.Split(s, sep)
+	sort.Strings(slice)
+	return slice
 }


### PR DESCRIPTION
**_Missed in my last PR_**

This PR will add tagging support for the HTTP check created by uptime which is already supported by uptime API:

```json
{
  "name": "string",
  "contact_groups": [
    "string"
  ],
  "locations": [
    "string"
  ],
 "tags": [
    "string"
  ],
  "msp_interval": 0,

  <REDACTED>
}
```