### PR TITLE
 add caching and fix uptime paginated response

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,13 +12,12 @@ require (
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/openshift/api v0.0.0-20200526144822-34f54f12813a
 	github.com/operator-framework/operator-sdk v0.19.0
-	github.com/rs/zerolog v1.20.0
+	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/russellcardullo/go-pingdom v1.3.0
 	github.com/sirupsen/logrus v1.6.0
 	github.com/stretchr/testify v1.5.1
 	google.golang.org/api v0.14.0
 	google.golang.org/genproto v0.0.0-20200117163144-32f20d992d24
-	gopkg.in/yaml.v1 v1.0.0-20140924161607-9f9df34309c0
 	gopkg.in/yaml.v2 v2.3.0
 	gotest.tools v2.2.0+incompatible
 	k8s.io/api v0.18.5

--- a/go.sum
+++ b/go.sum
@@ -684,6 +684,8 @@ github.com/otiai10/mint v1.3.0/go.mod h1:F5AjcsTsWUqX+Na9fpHb52P8pcRX2CI6A3ctIT9
 github.com/otiai10/mint v1.3.1/go.mod h1:/yxELlJQ0ufhjUwhshSj+wFjZ78CnZ48/1wtmBH1OTc=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
+github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
+github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
@@ -758,9 +760,6 @@ github.com/rogpeppe/go-internal v1.3.2/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTE
 github.com/rogpeppe/go-internal v1.4.0/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rogpeppe/go-internal v1.5.0/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rs/cors v1.6.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
-github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
-github.com/rs/zerolog v1.20.0 h1:38k9hgtUBdxFwE34yS8rTHmHBa4eN16E4DJlv177LNs=
-github.com/rs/zerolog v1.20.0/go.mod h1:IzD0RJ65iWH0w97OQQebJEvTZYvsCUm9WVLWBQrJRjo=
 github.com/rubenv/sql-migrate v0.0.0-20200212082348-64f95ea68aa3/go.mod h1:rtQlpHw+eR6UrqaS3kX1VYeaCxzCVdimDS7g5Ln4pPc=
 github.com/russellcardullo/go-pingdom v1.3.0 h1:uf5ZJOOR6BxqLcz0Lwmtb6HMFgX20CCLIhy0wB6tc/4=
 github.com/russellcardullo/go-pingdom v1.3.0/go.mod h1:y9hd/6P97iuRFi6VPGgLxsRQaJQll298jZ/qPQPfcXw=
@@ -1086,7 +1085,6 @@ golang.org/x/tools v0.0.0-20190628153133-6cdbf07be9d0/go.mod h1:/rFqwRUd4F7ZHNgw
 golang.org/x/tools v0.0.0-20190706070813-72ffa07ba3db/go.mod h1:jcCCGcm9btYwXyDqrUWc6MKQKKGJCWEQ3AfLSRIbEuI=
 golang.org/x/tools v0.0.0-20190813034749-528a2984e271/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20190816200558-6889da9d5479/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
-golang.org/x/tools v0.0.0-20190828213141-aed303cbaa74/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20190907020128-2ca718005c18/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20190911174233-4f2ddba30aff/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20190918214516-5a1a30219888/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
@@ -1199,8 +1197,6 @@ gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/square/go-jose.v2 v2.2.2/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
-gopkg.in/yaml.v1 v1.0.0-20140924161607-9f9df34309c0 h1:POO/ycCATvegFmVuPpQzZFJ+pGZeX22Ufu6fibxDVjU=
-gopkg.in/yaml.v1 v1.0.0-20140924161607-9f9df34309c0/go.mod h1:WDnlLJ4WF5VGsH/HVa3CI79GS0ol3YnhVnKP89i0kNg=
 gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=
 gopkg.in/yaml.v2 v2.1.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/pkg/controller/endpointmonitor/endpointmonitor_controller.go
+++ b/pkg/controller/endpointmonitor/endpointmonitor_controller.go
@@ -3,8 +3,9 @@ package endpointmonitor
 import (
 	"context"
 	"fmt"
-	log "github.com/sirupsen/logrus"
 	"time"
+
+	log "github.com/sirupsen/logrus"
 
 	endpointmonitorv1alpha1 "github.com/stakater/IngressMonitorController/pkg/apis/endpointmonitor/v1alpha1"
 	"github.com/stakater/IngressMonitorController/pkg/config"
@@ -125,7 +126,7 @@ func (r *ReconcileEndpointMonitor) Reconcile(request reconcile.Request) (reconci
 			// Monitor doesn't exist, create monitor
 			if delay.Nanoseconds() > 0 {
 				// Requeue request to add creation delay
-				log.Info("Requeuing request to add monitor " + monitorName + " for" + fmt.Sprintf("%+v", config.GetControllerConfig().CreationDelay) + " seconds")
+				log.Info("Requeuing request to add monitor " + monitorName + " for " + fmt.Sprintf("%+v", config.GetControllerConfig().CreationDelay) + " seconds")
 				return reconcile.Result{RequeueAfter: delay}, nil
 			}
 			err = r.handleCreate(request, instance, monitorName, r.monitorServices[index])

--- a/pkg/monitors/uptime/uptime-responses.go
+++ b/pkg/monitors/uptime/uptime-responses.go
@@ -2,8 +2,8 @@ package uptime
 
 type UptimeMonitorGetMonitorsResponse struct {
 	Count    int                    `json:"count"`
-	Next     int                    `json:"next"`
-	Previous int                    `json:"previous"`
+	Next     *string                `json:"next"`
+	Previous *string                `json:"previous"`
 	Monitors []UptimeMonitorMonitor `json:"results"`
 }
 
@@ -14,49 +14,54 @@ type UptimeMonitorPagination struct {
 }
 
 type UptimeMonitorMonitor struct {
-	PK                      int                      `json:"pk"`
-	URL                     string                   `json:"url"`
-	Name                    string                   `json:"name"`
-	CachedRespTime          float64                  `json:"cached_response_time"`
-	CachedUptime            float64                  `json:"cached_uptime"`
-	ContactGroups           []string                 `json:"contact_groups"`
-	CreatedAt               string                   `json:"created_at"`
-	ModifiedAt              string                   `json:"modified_at"`
-	Locations               []string                 `json:"locations"`
-	Tags                    []string                 `json:"tags"`
-	CheckType               string                   `json:"check_type"`
-	Escalations             []string                 `json:"escalations"`
-	Maintenance             UptimeMonitorMaintenance `json:"maintenance"`
-	MonitoringServiceType   string                   `json:"monitoring_service_type"`
-	IsPaused                bool                     `json:"is_paused"`
-	StateIsUp               bool                     `json:"state_is_up"`
-	MspScript               string                   `json:"msp_script"`
-	MspDNSRecordType        string                   `json:"msp_dns_record_type"`
-	MspIPVersion            string                   `json:"msp_use_ip_version"`
-	MspSensitivity          int                      `json:"msp_sensitivity"`
-	MspInterval             int                      `json:"msp_interval"`
-	MspHeaders              string                   `json:"msp_headers"`
-	MspNotes                string                   `json:"msp_notes"`
-	MspEncryption           string                   `json:"msp_encryption"`
-	MspExpectString         string                   `json:"msp_expect_string"`
-	MspAddress              string                   `json:"msp_address"`
-	MspProtocol             string                   `json:"msp_protocol"`
-	MspDNSServer            string                   `json:"msp_dns_server"`
-	MspSendString           string                   `json:"msp_send_string"`
-	MspUsername             string                   `json:"msp_username"`
-	MspExpectStringType     string                   `json:"msp_expect_string_type"`
-	MspPassword             string                   `json:"msp_password"`
-	MspThreshold            int                      `json:"msp_threshold"`
-	MspIncludeGlobalMetrics bool                     `json:"msp_include_global_metrics"`
-	MspPort                 int                      `json:"msp_port"`
-	StatsURL                string                   `json:"stats_url"`
-	AlertsURL               string                   `json:"alerts_url"`
+	PK                      int                        `json:"pk"`
+	URL                     string                     `json:"url"`
+	Name                    string                     `json:"name"`
+	CachedRespTime          float64                    `json:"cached_response_time"`
+	CachedUptime            float64                    `json:"cached_uptime"`
+	ContactGroups           []string                   `json:"contact_groups"`
+	CreatedAt               string                     `json:"created_at"`
+	ModifiedAt              string                     `json:"modified_at"`
+	Locations               []string                   `json:"locations"`
+	Tags                    []string                   `json:"tags"`
+	CheckType               string                     `json:"check_type"`
+	Escalations             []UptimeMonitorEscalations `json:"escalations"`
+	Maintenance             UptimeMonitorMaintenance   `json:"maintenance"`
+	MonitoringServiceType   string                     `json:"monitoring_service_type"`
+	IsPaused                bool                       `json:"is_paused"`
+	StateIsUp               bool                       `json:"state_is_up"`
+	MspScript               string                     `json:"msp_script"`
+	MspDNSRecordType        string                     `json:"msp_dns_record_type"`
+	MspIPVersion            string                     `json:"msp_use_ip_version"`
+	MspSensitivity          int                        `json:"msp_sensitivity"`
+	MspInterval             int                        `json:"msp_interval"`
+	MspHeaders              string                     `json:"msp_headers"`
+	MspNotes                string                     `json:"msp_notes"`
+	MspEncryption           string                     `json:"msp_encryption"`
+	MspExpectString         string                     `json:"msp_expect_string"`
+	MspAddress              string                     `json:"msp_address"`
+	MspProtocol             string                     `json:"msp_protocol"`
+	MspDNSServer            string                     `json:"msp_dns_server"`
+	MspSendString           string                     `json:"msp_send_string"`
+	MspUsername             string                     `json:"msp_username"`
+	MspExpectStringType     string                     `json:"msp_expect_string_type"`
+	MspPassword             string                     `json:"msp_password"`
+	MspThreshold            int                        `json:"msp_threshold"`
+	MspIncludeGlobalMetrics bool                       `json:"msp_include_global_metrics"`
+	MspPort                 int                        `json:"msp_port"`
+	StatsURL                string                     `json:"stats_url"`
+	AlertsURL               string                     `json:"alerts_url"`
 }
 
 type UptimeMonitorMaintenance struct {
 	Timezone string   `json:"timezone"`
 	State    string   `json:"state"`
 	Schedule []string `json:"schedule"`
+}
+
+type UptimeMonitorEscalations struct {
+	WaitTime      int      `json:"wait_time"`
+	ContactGroups []string `json:"contact_groups"`
 }
 
 type UptimeMonitorLogs struct {


### PR DESCRIPTION
Summary: If the number of HTTP checks in Uptime Monitor > 25 then it's being ignored by IMC as the current implementation [GetAll()](https://github.com/stakater/IngressMonitorController/blob/f81c7dd9d301a19e8223535cef9123c7cb911527/pkg/monitors/uptime/uptime-monitor.go#L57) is not handling paginated response.

This leads to an issue where after every reconcile, IMC tries to create a missing check (as it was not listed by `GetAll()` [checkHere](https://github.com/stakater/IngressMonitorController/blob/f81c7dd9d301a19e8223535cef9123c7cb911527/pkg/monitors/uptime/uptime-monitor.go#L46)) and failing to add monitor since it already exists:

Error Message:
```
INFO[0001] stakater not found
INFO[0001] Creating Monitor: stakater
INFO[0001] {"contact_groups":["Default"],"locations":["China","US Central","United Kingdom"],"msp_address":"https://stakater.com/","msp_interval":"1","name":"stakater","tags":["Core"]}
INFO[0002] AddMonitor Request failed. Status Code: 400
{"messages":{"errors":true,"error_code":"VALIDATION_ERROR","error_message":"One or more fields failed validation.","error_fields":{"name":["A service check with this name already exists."]}}}
```



With this PR, I have added pagination support for the GetAll() using the Next key also added support for in-memory caching for the HTTP response to avoid API rate limit issue for every reconcile loop.
