### PR TITLE
fix: typo {{ template name . }}-cluster--role => {{ template name . }}-cluster-role

### DIFF
--- a/deploy/chart/ingressmonitorcontroller/templates/clusterrolebinding.yaml
+++ b/deploy/chart/ingressmonitorcontroller/templates/clusterrolebinding.yaml
@@ -7,7 +7,7 @@ metadata:
 {{ include "labels" $ | indent 4 }}
 roleRef:
   kind: ClusterRole
-  name: {{ template "name" . }}-cluster--role
+  name: {{ template "name" . }}-cluster-role
   apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: ServiceAccount


### PR DESCRIPTION
> /!\ Only the helm chart was modified

The new helm chart released yesterday contains a typo in the ClusterRoleBinding template when using `watchNamespaces: ""`, RBAC and SA.