### PR TITLE
Allow to set kube-rbac-proxy Docker image and by default use the one from upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,16 @@ helm repo update
 helm install stakater/ingressmonitorcontroller
 ```
 
+### OpenStack
+
+Due to [a bug](https://github.com/operator-framework/operator-sdk/issues/4684),
+installation on OpenStack requires using an image of [kube-rbac-proxy](https://github.com/brancz/kube-rbac-proxy)
+provided by Red Hat:
+
+```
+helm install --set kube-rbac-proxy.image.repository=registry.redhat.io/openshift4/ose-kube-rbac-proxy,kube-rbac-proxy.image.tag=v4.7.0 stakater/ingressmonitorcontroller
+```
+
 ## Vanilla Manifests
 
 1. Clone this repository

--- a/charts/ingressmonitorcontroller/README.md
+++ b/charts/ingressmonitorcontroller/README.md
@@ -11,6 +11,8 @@ Source code can be found [here](https://github.com/stakater/IngressMonitorContro
 To install IMC helm chart run the following
 
 ```sh
+# Install CRDs
+kubectl apply -f https://raw.githubusercontent.com/stakater/IngressMonitorController/master/deploy/crds/endpointmonitor.stakater.com_endpointmonitors_crd.yaml
 
 # Install Chart
 helm repo add stakater https://stakater.github.io/stakater-charts
@@ -20,33 +22,46 @@ helm repo update
 helm install stakater/ingressmonitorcontroller
 ```
 
+### OpenStack
+
+Due to [a bug](https://github.com/operator-framework/operator-sdk/issues/4684),
+installation on OpenStack requires using an image of [kube-rbac-proxy](https://github.com/brancz/kube-rbac-proxy)
+provided by Red Hat:
+
+```
+helm install --set kube-rbac-proxy.image.repository=registry.redhat.io/openshift4/ose-kube-rbac-proxy,kube-rbac-proxy.image.tag=v4.7.0 stakater/ingressmonitorcontroller
+```
+
 ## Chart Values
 
-| Key                          | Default                               | Description                                                                                    |
-| ---------------------------- | ------------------------------------- | ---------------------------------------------------------------------------------------------- |
-| global.labels                | ``                                    | Labels to be added to all components                                                           |
-| replicaCount                 | `1`                                   | Replicas for operator                                                                          |
-| image.name                   | `"stakater/ingressmonitorcontroller"` | Image repository                                                                               |
-| image.tag                    | `LATEST_CHART_VERSION`                | Tag of the Image                                                                               |
-| image.pullPolicy             | `Always`                              | Pull policy for the image                                                                      |
-| imagePullSecrets             | ``                                    | List of secrets used to pull images                                                            |
-| nameOverride                 | `""`                                  | Partial override for ingress-monitor-controller.fullname template (will keep the release name) |
-| fullnameOverride             | `""`                                  | Full override for ingress-monitor-controller.fullname template                                 |
-| watchNamespaces              | `""`                                  | Comma separated namespace names, set empty to watch all namespaces                             |
-| configSecretName             | `"imc-config"`                        | Name of secret that contains configuration                                                     |
-| rbac.create                  | `true`                                | Whether to create RBAC                                                                         |
-| rbac.allowProxyRole          | `true`                                | Whether to create RBAC for proxy                                                               |
-| rbac.allowMetricsReaderRole  | `true`                                | Whether to create RBAC for metrics-reader                                                      |
-| rbac.allowLeaderElectionRole | `true`                                | Whether to create leader-election                                                              |
-| serviceAccount.create        | `true`                                | Whether to create serviceAccount                                                               |
-| serviceAccount.name          | `""`                                  | Name for ServiceAccount, if empty the default chart name will be used                          |
-| serviceAccount.labels        | `{}`                                  | Additional labels on ServiceAccount                                                            |
-| serviceAccount.annotations   | `{}`                                  | Additional annotations on ServiceAccount                                                       |
-| serviceMonitor.enabled       | `false`                               | Create ServiceMonitor for metrics                                                              |
-| podAnnotations               | `""`                                  | Additional annotations on deployment                                                           |
-| resources                    | `{}`                                  | Requests/Limits for operator                                                                   |
-| securityContext              | `{}`                                  | Override for SecurityContext                                                                   |
-| podSecurityContext           | `{}`                                  | Override for deployment.Spec.securityContext                                                   |
-| nodeSelector                 | `{}`                                  | Override for NodeSelector                                                                      |
-| tolerations                  | `{}`                                  | Override for Tolerations                                                                       |
-| affinity                     | `{}`                                  | Override for Affinity                                                                          |
+| Key                              | Default                                   | Description                                                                                    |
+| -------------------------------- | ----------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| global.labels                    | ``                                        | Labels to be added to all components                                                           |
+| replicaCount                     | `1`                                       | Replicas for operator                                                                          |
+| image.repository                 | `"stakater/ingressmonitorcontroller"`     | Image repository                                                                               |
+| image.tag                        | `LATEST_CHART_VERSION`                    | Tag of the Image                                                                               |
+| image.pullPolicy                 | `IfNotPresent`                            | Pull policy for the image                                                                      |
+| imagePullSecrets                 | ``                                        | List of secrets used to pull images                                                            |
+| nameOverride                     | `""`                                      | Partial override for ingress-monitor-controller.fullname template (will keep the release name) |
+| fullnameOverride                 | `""`                                      | Full override for ingress-monitor-controller.fullname template                                 |
+| watchNamespaces                  | `""`                                      | Comma separated namespace names, set empty to watch all namespaces                             |
+| configSecretName                 | `"imc-config"`                            | Name of secret that contains configuration                                                     |
+| rbac.create                      | `true`                                    | Whether to create RBAC                                                                         |
+| rbac.allowProxyRole              | `true`                                    | Whether to create RBAC for proxy                                                               |
+| rbac.allowMetricsReaderRole      | `true`                                    | Whether to create RBAC for metrics-reader                                                      |
+| rbac.allowLeaderElectionRole     | `true`                                    | Whether to create leader-election                                                              |
+| serviceAccount.create            | `true`                                    | Whether to create serviceAccount                                                               |
+| serviceAccount.name              | `""`                                      | Name for ServiceAccount, if empty the default chart name will be used                          |
+| serviceAccount.labels            | `{}`                                      | Additional labels on ServiceAccount                                                            |
+| serviceAccount.annotations       | `{}`                                      | Additional annotations on ServiceAccount                                                       |
+| serviceMonitor.enabled           | `false`                                   | Create ServiceMonitor for metrics                                                              |
+| podAnnotations                   | `""`                                      | Additional annotations on deployment                                                           |
+| resources                        | `{}`                                      | Requests/Limits for operator                                                                   |
+| securityContext                  | `{}`                                      | Override for SecurityContext                                                                   |
+| podSecurityContext               | `{}`                                      | Override for deployment.Spec.securityContext                                                   |
+| nodeSelector                     | `{}`                                      | Override for NodeSelector                                                                      |
+| tolerations                      | `{}`                                      | Override for Tolerations                                                                       |
+| affinity                         | `{}`                                      | Override for Affinity                                                                          |
+| kube-rbac-proxy.image.repository | `"http://quay.io/brancz/kube-rbac-proxy"` | Image repository                                                                               |
+| kube-rbac-proxy.image.tag        | `v0.1.0`                                  | Tag of the Image                                                                               |
+| kube-rbac-proxy.image.pullPolicy | `IfNotPresent`                            | Pull policy for the image                                                                      |

--- a/charts/ingressmonitorcontroller/templates/deployment.yaml
+++ b/charts/ingressmonitorcontroller/templates/deployment.yaml
@@ -28,18 +28,19 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
+      {{- with (index .Values "kube-rbac-proxy") }}
       - args:
         - --secure-listen-address=0.0.0.0:8443
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=10
-        # Issue: https://github.com/operator-framework/operator-sdk/issues/4813
-        image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.7.0
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        image: {{ printf "%s:%s" .image.repository .image.tag | quote }}
+        imagePullPolicy: {{ .image.pullPolicy | quote }}
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443
           name: https
+      {{- end }}
       - args:
         - --health-probe-bind-address=:8081
         - --metrics-bind-address=127.0.0.1:8080

--- a/charts/ingressmonitorcontroller/values.yaml
+++ b/charts/ingressmonitorcontroller/values.yaml
@@ -78,3 +78,9 @@ service:
 env: []
 
 envFrom: []
+
+kube-rbac-proxy:
+  image:
+    repository: quay.io/brancz/kube-rbac-proxy
+    tag: v0.10.0
+    pullPolicy: IfNotPresent

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -10,8 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        # Issue: https://github.com/operator-framework/operator-sdk/issues/4813
-        image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.7.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.10.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"


### PR DESCRIPTION
After merging #331, IngressMonitorController cannot be installed on a vanilla Kubernetes due to a fact that the image used by kube-rbac-proxy is in Red Hat's Docker image registry which requires authentication:

```
Events:
  Type     Reason     Age                From               Message
  ----     ------     ----               ----               -------
  Normal   Scheduled  94s                default-scheduler  Successfully assigned default/ingressmonitorcontroller-9b7569b65-vsmdk to kind-control-plane
  Normal   Pulled     92s                kubelet            Container image "stakater/ingressmonitorcontroller:v2.1.3" already present on machine
  Normal   Created    91s                kubelet            Created container manager
  Normal   Started    91s                kubelet            Started container manager
  Warning  Failed     51s (x3 over 92s)  kubelet            Failed to pull image "registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.7.0": rpc error: code = Unknown desc = failed to pull and unpack image "registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.7.0": failed to resolve reference "registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.7.0": failed to authorize: failed to fetch anonymous token: unexpected status: 401 Unauthorized
  Warning  Failed     51s (x3 over 92s)  kubelet            Error: ErrImagePull
  Normal   BackOff    12s (x6 over 90s)  kubelet            Back-off pulling image "registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.7.0"
  Warning  Failed     12s (x6 over 90s)  kubelet            Error: ImagePullBackOff
  Normal   Pulling    1s (x4 over 93s)   kubelet            Pulling image "registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.7.0"
```

This PR allows to set a different image for kube-rbac-proxy and sets the one provided by the upstream project as a default.