### PR TITLE
Install CRDs using hook for Helm 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,14 +123,15 @@ The following quickstart let's you set up Ingress Monitor Controller to register
 If you have configured helm on your cluster, you can deploy IngressMonitorController via helm using below mentioned commands. For details on chart, see [IMC Helm Chart](https://github.com/stakater/IngressMonitorController/tree/master/deploy/chart/ingressmonitorcontroller)
 
 ```sh
-# Install CRDs
-kubectl apply -f https://raw.githubusercontent.com/stakater/IngressMonitorController/master/deploy/crds/endpointmonitor.stakater.com_endpointmonitors_crd.yaml
-
 # Install chart
 helm repo add stakater https://stakater.github.io/stakater-charts
 
 helm repo update
 
+# Helm 2
+helm install --set installCRDs=true stakater/ingressmonitorcontroller
+
+# Helm 3
 helm install stakater/ingressmonitorcontroller
 ```
 

--- a/charts/ingressmonitorcontroller/README.md
+++ b/charts/ingressmonitorcontroller/README.md
@@ -17,6 +17,10 @@ helm repo add stakater https://stakater.github.io/stakater-charts
 
 helm repo update
 
+# Helm 2
+helm install --set installCRDs=true stakater/ingressmonitorcontroller
+
+# Helm 3
 helm install stakater/ingressmonitorcontroller
 ```
 
@@ -25,6 +29,7 @@ helm install stakater/ingressmonitorcontroller
 | Key                          | Default                               | Description                                                                                    |
 | ---------------------------- | ------------------------------------- | ---------------------------------------------------------------------------------------------- |
 | global.labels                | ``                                    | Labels to be added to all components                                                           |
+| installCRDs                  | false                                 | Whether to install CRDs (Helm 2)                                                               |
 | replicaCount                 | `1`                                   | Replicas for operator                                                                          |
 | image.name                   | `"stakater/ingressmonitorcontroller"` | Image repository                                                                               |
 | image.tag                    | `LATEST_CHART_VERSION`                | Tag of the Image                                                                               |
@@ -50,3 +55,5 @@ helm install stakater/ingressmonitorcontroller
 | nodeSelector                 | `{}`                                  | Override for NodeSelector                                                                      |
 | tolerations                  | `{}`                                  | Override for Tolerations                                                                       |
 | affinity                     | `{}`                                  | Override for Affinity                                                                          |
+| env                          | `{}`                                  | Additional environment variables in the manager container                                      |
+| envFrom                      | `{}`                                  | Additional sources to populate environment variables in the manager container                  |

--- a/charts/ingressmonitorcontroller/templates/crds.yaml
+++ b/charts/ingressmonitorcontroller/templates/crds.yaml
@@ -1,0 +1,6 @@
+{{- if .Values.installCRDs -}}
+{{- range $path, $_ :=  .Files.Glob  "crds/*.yaml" }}
+{{- $crd := merge (dict "metadata" (dict "annotations" (dict "helm.sh/hook" "crd-install"))) (fromYaml ($.Files.Get $path)) -}}
+{{ toYaml $crd }}
+{{- end }}
+{{- end -}}

--- a/charts/ingressmonitorcontroller/values.yaml
+++ b/charts/ingressmonitorcontroller/values.yaml
@@ -2,6 +2,8 @@ global:
   # labels added on all components of chart in addition to some default labels
   labels: {}
 
+installCRDs: false
+
 replicaCount: 1
 
 image:


### PR DESCRIPTION
Some of the GitOps tools (e.g. Argo CD) decide on which Helm version to use based on the version set in `Chart.yaml` (`apiVersion: v1` for Helm 2 and `apiVersion: v2` for Helm 3).

[Helm 3 is capable of installing CRDs by putting the files in the `crds` directory](https://helm.sh/docs/chart_best_practices/custom_resource_definitions/#method-1-let-helm-do-it-for-you).

To support the previous version of Helm (it's already deprecated but adjusting the chart to the newest version requires changing the API version in `Chart.yaml`), [installing CRDs should be also possible by using a hook](https://v2.helm.sh/docs/developing_charts/#defining-a-crd-with-the-crd-install-hook).