### PR TITLE
Revert kube-rbac-proxy image tag to v0.8.0

### DIFF
--- a/charts/ingressmonitorcontroller/values.yaml
+++ b/charts/ingressmonitorcontroller/values.yaml
@@ -13,7 +13,7 @@ imagePullSecrets: []
 kube-rbac-proxy:
   image:
     repository: gcr.io/kubebuilder/kube-rbac-proxy
-    tag: v2.1.5
+    tag: v0.8.0
     pullPolicy: IfNotPresent
 
 # Partial override for ingress-monitor-controller.fullname template (will keep the release name)


### PR DESCRIPTION
Looks like the automatic artifact update got a bit carried away and it updated the `kube-rbac-proxy` image tag to a version that doesn't exist. 

```Failed to pull image "gcr.io/kubebuilder/kube-rbac-proxy:v2.1.5": rpc error: code = Unknown desc = Error response from daemon: manifest for gcr.io/kubebuilder/kube-rbac-proxy:v2.1.5 not found: manifest unknown: Failed to fetch "v2.1.5"```

Reverting back to `v0.8.0` which is the correct version to use. 