### PR TITLE
Fixes log format across the board

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ If you have configured helm on your cluster, you can deploy IngressMonitorContro
 
 ```sh
 # Install CRDs
-kubectl apply -f https://raw.githubusercontent.com/stakater/IngressMonitorController/master/deploy/crds/endpointmonitor.stakater.com_endpointmonitors_crd.yaml
+kubectl apply -f https://raw.githubusercontent.com/stakater/IngressMonitorController/master/charts/ingressmonitorcontroller/crds/endpointmonitor.stakater.com_endpointmonitors.yaml
 
 # Install chart
 helm repo add stakater https://stakater.github.io/stakater-charts

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -144,7 +144,7 @@ func GetControllerConfigTest() Config {
 func ReadConfig(filePath string) Config {
 	var config Config
 	// Read YML
-	log.Info("Reading YAML Configuration: ", filePath)
+	log.Info("Reading YAML Configuration: " + filePath)
 	source, err := ioutil.ReadFile(filePath)
 	if err != nil {
 		panic(err)

--- a/pkg/kube/wrappers/ingress-wrapper.go
+++ b/pkg/kube/wrappers/ingress-wrapper.go
@@ -2,6 +2,7 @@ package wrappers
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 	"path"
 	"strings"
@@ -91,7 +92,7 @@ func (iw *IngressWrapper) GetURL(forceHttps bool, healthEndpoint string) string 
 	u, err := url.Parse(URL)
 
 	if err != nil {
-		log.Info("URL parsing error in getURL() :%v", err)
+		log.Info(fmt.Sprintf("URL parsing error in getURL() :%v", err))
 		return ""
 	}
 
@@ -134,7 +135,7 @@ func (iw *IngressWrapper) tryGetHealthEndpointFromIngress() (string, bool) {
 	service := &corev1.Service{}
 	err := iw.Client.Get(context.TODO(), types.NamespacedName{Name: serviceName, Namespace: iw.Ingress.Namespace}, service)
 	if err != nil {
-		log.Info("Get service from kubernetes cluster error:%v", err)
+		log.Info(fmt.Sprintf("Get service from kubernetes cluster error:%v", err))
 		return "", false
 	}
 
@@ -147,7 +148,7 @@ func (iw *IngressWrapper) tryGetHealthEndpointFromIngress() (string, bool) {
 	}
 	err = iw.Client.List(context.TODO(), podList, listOps)
 	if err != nil {
-		log.Info("List Pods of service[%s] error:%v", service.GetName(), err)
+		log.Info(fmt.Sprintf("List Pods of service[%s] error:%v", service.GetName(), err))
 	} else if len(podList.Items) > 0 {
 		pod := podList.Items[0]
 
@@ -158,7 +159,7 @@ func (iw *IngressWrapper) tryGetHealthEndpointFromIngress() (string, bool) {
 				return podContainers[0].ReadinessProbe.HTTPGet.Path, true
 			}
 		} else {
-			log.Info("Pod has %d containers so skipping health endpoint", len(podContainers))
+			log.Info(fmt.Sprintf("Pod has %d containers so skipping health endpoint", len(podContainers)))
 		}
 	}
 

--- a/pkg/kube/wrappers/routeWrapper.go
+++ b/pkg/kube/wrappers/routeWrapper.go
@@ -2,6 +2,7 @@ package wrappers
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 	"path"
 
@@ -67,7 +68,7 @@ func (rw *RouteWrapper) tryGetHealthEndpointFromRoute() (string, bool) {
 	service := &corev1.Service{}
 	err := rw.Client.Get(context.TODO(), types.NamespacedName{Name: serviceName, Namespace: rw.Route.Namespace}, service)
 	if err != nil {
-		log.Info("Get service from kubernetes cluster error:%v", err)
+		log.Info(fmt.Sprintf("Get service from kubernetes cluster error:%v", err))
 		return "", false
 	}
 
@@ -80,7 +81,7 @@ func (rw *RouteWrapper) tryGetHealthEndpointFromRoute() (string, bool) {
 	}
 	err = rw.Client.List(context.TODO(), podList, listOps)
 	if err != nil {
-		log.Info("List Pods of service[%s] error:%v", service.GetName(), err)
+		log.Info(fmt.Sprintf("List Pods of service[%s] error:%v", service.GetName(), err))
 	} else if len(podList.Items) > 0 {
 		pod := podList.Items[0]
 		podContainers := pod.Spec.Containers
@@ -90,7 +91,7 @@ func (rw *RouteWrapper) tryGetHealthEndpointFromRoute() (string, bool) {
 				return podContainers[0].ReadinessProbe.HTTPGet.Path, true
 			}
 		} else {
-			log.Info("Pod has %d containers so skipping health endpoint", len(podContainers))
+			log.Info(fmt.Sprintf("Pod has %d containers so skipping health endpoint", len(podContainers)))
 		}
 	}
 
@@ -110,7 +111,7 @@ func (rw *RouteWrapper) GetURL(forceHttps bool, healthEndpoint string) string {
 	u, err := url.Parse(URL)
 
 	if err != nil {
-		log.Info("URL parsing error in getURL() :%v", err)
+		log.Info(fmt.Sprintf("URL parsing error in getURL() :%v", err))
 		return ""
 	}
 

--- a/pkg/monitors/appinsights/appinsights-monitor.go
+++ b/pkg/monitors/appinsights/appinsights-monitor.go
@@ -214,22 +214,22 @@ func (aiService *AppinsightsMonitorService) GetByName(monitorName string) (*mode
 func (aiService *AppinsightsMonitorService) Add(monitor models.Monitor) {
 
 	log.Info("AppInsights Monitor's Add method has been called")
-	log.Info("Adding Application Insights WebTest '%s' from '%s'", monitor.Name, aiService.name)
+	log.Info(fmt.Sprintf("Adding Application Insights WebTest '%s' from '%s'", monitor.Name, aiService.name))
 	webtest := aiService.createWebTest(monitor)
 	_, err := aiService.insightsClient.CreateOrUpdate(aiService.ctx, aiService.resourceGroup, monitor.Name, webtest)
 	if err != nil {
-		log.Error(err, "Error adding Application Insights WebTests %s (Resource Group %s): %v", monitor.Name, aiService.resourceGroup, err)
+		log.Error(err, fmt.Sprintf("Error adding Application Insights WebTests %s (Resource Group %s): %v", monitor.Name, aiService.resourceGroup, err))
 	} else {
-		log.Info("Successfully added Application Insights WebTest %s (Resource Group %s)", monitor.Name, aiService.resourceGroup)
+		log.Info(fmt.Sprintf("Successfully added Application Insights WebTest %s (Resource Group %s)", monitor.Name, aiService.resourceGroup))
 		if aiService.isAlertEnabled() {
-			log.Info("Adding alert rule for WebTest '%s' from '%s'", monitor.Name, aiService.name)
+			log.Info(fmt.Sprintf("Adding alert rule for WebTest '%s' from '%s'", monitor.Name, aiService.name))
 			alertName := fmt.Sprintf("%s-alert", monitor.Name)
 			webtestAlert := aiService.createAlertRuleResource(monitor)
 			_, err := aiService.alertrulesClient.CreateOrUpdate(aiService.ctx, aiService.resourceGroup, alertName, webtestAlert)
 			if err != nil {
-				log.Error(err, "Error adding alert rule for WebTests %s (Resource Group %s): %v", monitor.Name, aiService.resourceGroup, err)
+				log.Error(err, fmt.Sprintf("Error adding alert rule for WebTests %s (Resource Group %s): %v", monitor.Name, aiService.resourceGroup, err))
 			}
-			log.Info("Successfully added Alert rule for WebTest %s (Resource Group %s)", monitor.Name, aiService.resourceGroup)
+			log.Info(fmt.Sprintf("Successfully added Alert rule for WebTest %s (Resource Group %s)", monitor.Name, aiService.resourceGroup))
 		}
 	}
 
@@ -239,23 +239,23 @@ func (aiService *AppinsightsMonitorService) Add(monitor models.Monitor) {
 func (aiService *AppinsightsMonitorService) Update(monitor models.Monitor) {
 
 	log.Info("AppInsights Monitor's Update method has been called")
-	log.Info("Updating Application Insights WebTest '%s' from '%s'", monitor.Name, aiService.name)
+	log.Info(fmt.Sprintf("Updating Application Insights WebTest '%s' from '%s'", monitor.Name, aiService.name))
 
 	webtest := aiService.createWebTest(monitor)
 	_, err := aiService.insightsClient.CreateOrUpdate(aiService.ctx, aiService.resourceGroup, monitor.Name, webtest)
 	if err != nil {
-		log.Error(err, "Error updating Application Insights WebTests %s (Resource Group %s): %v", monitor.Name, aiService.resourceGroup, err)
+		log.Error(err, fmt.Sprintf("Error updating Application Insights WebTests %s (Resource Group %s): %v", monitor.Name, aiService.resourceGroup, err))
 	} else {
-		log.Info("Successfully updated Application Insights WebTest %s (Resource Group %s)", monitor.Name, aiService.resourceGroup)
+		log.Info(fmt.Sprintf("Successfully updated Application Insights WebTest %s (Resource Group %s)", monitor.Name, aiService.resourceGroup))
 		if aiService.isAlertEnabled() {
-			log.Info("Updating alert rule for WebTest '%s' from '%s'", monitor.Name, aiService.name)
+			log.Info(fmt.Sprintf("Updating alert rule for WebTest '%s' from '%s'", monitor.Name, aiService.name))
 			alertName := fmt.Sprintf("%s-alert", monitor.Name)
 			webtestAlert := aiService.createAlertRuleResource(monitor)
 			_, err := aiService.alertrulesClient.CreateOrUpdate(aiService.ctx, aiService.resourceGroup, alertName, webtestAlert)
 			if err != nil {
-				log.Error(err, "Error updating alert rule for WebTests %s (Resource Group %s): %v", monitor.Name, aiService.resourceGroup, err)
+				log.Error(err, fmt.Sprintf("Error updating alert rule for WebTests %s (Resource Group %s): %v", monitor.Name, aiService.resourceGroup, err))
 			}
-			log.Info("Successfully updating Alert rule for WebTest %s (Resource Group %s)", monitor.Name, aiService.resourceGroup)
+			log.Info(fmt.Sprintf("Successfully updating Alert rule for WebTest %s (Resource Group %s)", monitor.Name, aiService.resourceGroup))
 		}
 	}
 }
@@ -264,26 +264,26 @@ func (aiService *AppinsightsMonitorService) Update(monitor models.Monitor) {
 func (aiService *AppinsightsMonitorService) Remove(monitor models.Monitor) {
 
 	log.Info("AppInsights Monitor's Remove method has been called")
-	log.Info("Deleting Application Insights WebTest '%s' from '%s'", monitor.Name, aiService.name)
+	log.Info(fmt.Sprintf("Deleting Application Insights WebTest '%s' from '%s'", monitor.Name, aiService.name))
 	r, err := aiService.insightsClient.Delete(aiService.ctx, aiService.resourceGroup, monitor.Name)
 	if err != nil {
 		if r.Response.StatusCode == http.StatusNotFound {
-			log.Error(err, "Application Insights WebTest %s was not found in Resource Group %s", monitor.Name, aiService.resourceGroup)
+			log.Error(err, fmt.Sprintf("Application Insights WebTest %s was not found in Resource Group %s", monitor.Name, aiService.resourceGroup))
 		}
-		log.Error(err, "Error deleting Application Insights WebTests %s (Resource Group %s): %v", monitor.Name, aiService.resourceGroup, err)
+		log.Error(err, fmt.Sprintf("Error deleting Application Insights WebTests %s (Resource Group %s): %v", monitor.Name, aiService.resourceGroup, err))
 	} else {
-		log.Info("Successfully removed Application Insights WebTest %s (Resource Group %s)", monitor.Name, aiService.resourceGroup)
+		log.Info(fmt.Sprintf("Successfully removed Application Insights WebTest %s (Resource Group %s)", monitor.Name, aiService.resourceGroup))
 		if aiService.isAlertEnabled() {
-			log.Info("Deleting alert rule for WebTest '%s' from '%s'", monitor.Name, aiService.name)
+			log.Info(fmt.Sprintf("Deleting alert rule for WebTest '%s' from '%s'", monitor.Name, aiService.name))
 			alertName := fmt.Sprintf("%s-alert", monitor.Name)
 			r, err := aiService.alertrulesClient.Delete(aiService.ctx, aiService.resourceGroup, alertName)
 			if err != nil {
 				if r.Response.StatusCode == http.StatusNotFound {
-					log.Error(err, "WebTest Alert rule %s was not found in Resource Group %s", alertName, aiService.resourceGroup)
+					log.Error(err, fmt.Sprintf("WebTest Alert rule %s was not found in Resource Group %s", alertName, aiService.resourceGroup))
 				}
-				log.Error(err, "Error deleting alert rule for WebTests %s (Resource Group %s): %v", alertName, aiService.resourceGroup, err)
+				log.Error(err, fmt.Sprintf("Error deleting alert rule for WebTests %s (Resource Group %s): %v", alertName, aiService.resourceGroup, err))
 			}
-			log.Info("Successfully removed Alert rule for WebTest %s (Resource Group %s)", monitor.Name, aiService.resourceGroup)
+			log.Info(fmt.Sprintf("Successfully removed Alert rule for WebTest %s (Resource Group %s)", monitor.Name, aiService.resourceGroup))
 		}
 	}
 }

--- a/pkg/monitors/gcloud/gcloud-monitor.go
+++ b/pkg/monitors/gcloud/gcloud-monitor.go
@@ -38,7 +38,7 @@ func (service *MonitorService) Setup(provider config.Provider) {
 	client, err := monitoring.NewUptimeCheckClient(service.ctx, option.WithCredentialsJSON([]byte(provider.ApiKey)))
 
 	if err != nil {
-		log.Info("Error Seting Up Monitor Service: ", err.Error())
+		log.Info("Error Seting Up Monitor Service: " + err.Error())
 	} else {
 		service.client = client
 	}
@@ -79,7 +79,7 @@ func (service *MonitorService) GetAll() (monitors []models.Monitor) {
 			break
 		}
 		if err != nil {
-			log.Info("Error received while listing checks: ", err.Error())
+			log.Info("Error received while listing checks: " + err.Error())
 			return nil
 		}
 		monitors = append(monitors, transformToMonitor(uptimeCheckConfig))
@@ -91,7 +91,7 @@ func (service *MonitorService) GetAll() (monitors []models.Monitor) {
 func (service *MonitorService) Add(monitor models.Monitor) {
 	url, err := url.Parse(monitor.URL)
 	if err != nil {
-		log.Info("Error Adding Monitor: ", err.Error())
+		log.Info("Error Adding Monitor: " + err.Error())
 		return
 	}
 
@@ -103,13 +103,13 @@ func (service *MonitorService) Add(monitor models.Monitor) {
 		} else if url.Scheme == "https" {
 			port = 443
 		} else {
-			log.Info("Error Adding Monitor: unknown protocol ", url.Scheme)
+			log.Info("Error Adding Monitor: unknown protocol " + url.Scheme)
 			return
 		}
 	} else {
 		port, err = strconv.Atoi(portString)
 		if err != nil {
-			log.Info("Error Adding Monitor: ", err.Error())
+			log.Info("Error Adding Monitor: " + err.Error())
 			return
 		}
 	}
@@ -142,22 +142,22 @@ func (service *MonitorService) Add(monitor models.Monitor) {
 		},
 	})
 	if err != nil {
-		log.Info("Error Adding Monitor: ", err.Error())
+		log.Info("Error Adding Monitor: " + err.Error())
 		return
 	}
 
-	log.Info("Added monitor for: ", monitor.Name)
+	log.Info("Added monitor for: " + monitor.Name)
 }
 
 func (service *MonitorService) Update(monitor models.Monitor) {
 	uptimeCheckConfig, err := service.client.GetUptimeCheckConfig(service.ctx, &monitoringpb.GetUptimeCheckConfigRequest{Name: monitor.ID})
 	if err != nil {
-		log.Info("Error updating Monitor: ", err.Error())
+		log.Info("Error updating Monitor: " + err.Error())
 	}
 
 	url, err := url.Parse(monitor.URL)
 	if err != nil {
-		log.Info("Error Adding Monitor: ", err.Error())
+		log.Info("Error Adding Monitor: " + err.Error())
 		return
 	}
 
@@ -174,13 +174,13 @@ func (service *MonitorService) Update(monitor models.Monitor) {
 		} else if url.Scheme == "https" {
 			port = 443
 		} else {
-			log.Info("Error Adding Monitor: unknown protocol ", url.Scheme)
+			log.Info("Error Adding Monitor: unknown protocol " + url.Scheme)
 			return
 		}
 	} else {
 		port, err = strconv.Atoi(portString)
 		if err != nil {
-			log.Info("Error Adding Monitor: ", err.Error())
+			log.Info("Error Adding Monitor: " + err.Error())
 			return
 		}
 	}
@@ -193,11 +193,11 @@ func (service *MonitorService) Update(monitor models.Monitor) {
 		UptimeCheckConfig: uptimeCheckConfig,
 	})
 	if err != nil {
-		log.Info("Error Adding Monitor: ", err.Error())
+		log.Info("Error Adding Monitor: " + err.Error())
 		return
 	}
 
-	log.Info("Updated Monitor: ", uptimeCheckConfig)
+	log.Info(fmt.Sprintf("Updated Monitor: %v", uptimeCheckConfig))
 }
 
 func (service *MonitorService) Remove(monitor models.Monitor) {
@@ -205,10 +205,10 @@ func (service *MonitorService) Remove(monitor models.Monitor) {
 		Name: monitor.ID,
 	})
 	if err != nil {
-		log.Info("Error deleting Monitor: ", err.Error())
+		log.Info("Error deleting Monitor: " + err.Error())
 		return
 	}
-	log.Info("Deleted Monitor: ", monitor.Name)
+	log.Info("Deleted Monitor: " + monitor.Name)
 }
 
 func transformToMonitor(uptimeCheckConfig *monitoringpb.UptimeCheckConfig) (monitor models.Monitor) {

--- a/pkg/monitors/pingdom/pingdom-monitor.go
+++ b/pkg/monitors/pingdom/pingdom-monitor.go
@@ -47,7 +47,7 @@ func (service *PingdomMonitorService) Setup(p config.Provider) {
 		BaseURL:  service.url,
 	})
 	if err != nil {
-		log.Info("Error Seting Up Monitor Service: ", err.Error())
+		log.Info("Error Seting Up Monitor Service: " + err.Error())
 	}
 }
 
@@ -69,7 +69,7 @@ func (service *PingdomMonitorService) GetAll() []models.Monitor {
 
 	checks, err := service.client.Checks.List()
 	if err != nil {
-		log.Info("Error received while listing checks: ", err.Error())
+		log.Info("Error received while listing checks: " + err.Error())
 		return nil
 	}
 	for _, mon := range checks {
@@ -89,9 +89,9 @@ func (service *PingdomMonitorService) Add(m models.Monitor) {
 
 	_, err := service.client.Checks.Create(&httpCheck)
 	if err != nil {
-		log.Info("Error Adding Monitor: ", err.Error())
+		log.Info("Error Adding Monitor: " + err.Error())
 	} else {
-		log.Info("Added monitor for: ", m.Name)
+		log.Info("Added monitor for: " + m.Name)
 	}
 }
 
@@ -101,9 +101,9 @@ func (service *PingdomMonitorService) Update(m models.Monitor) {
 
 	resp, err := service.client.Checks.Update(monitorID, &httpCheck)
 	if err != nil {
-		log.Info("Error updating Monitor: ", err.Error())
+		log.Info("Error updating Monitor: " + err.Error())
 	} else {
-		log.Info("Updated Monitor: ", resp)
+		log.Info(fmt.Sprintf("Updated Monitor: %v", resp))
 	}
 }
 
@@ -112,9 +112,9 @@ func (service *PingdomMonitorService) Remove(m models.Monitor) {
 
 	resp, err := service.client.Checks.Delete(monitorID)
 	if err != nil {
-		log.Info("Error deleting Monitor: ", err.Error())
+		log.Info("Error deleting Monitor: " + err.Error())
 	} else {
-		log.Info("Delete Monitor: ", resp)
+		log.Info(fmt.Sprintf("Delete Monitor: %v", resp))
 	}
 }
 
@@ -122,7 +122,7 @@ func (service *PingdomMonitorService) createHttpCheck(monitor models.Monitor) pi
 	httpCheck := pingdom.HttpCheck{}
 	url, err := url.Parse(monitor.URL)
 	if err != nil {
-		log.Info("Unable to parse the URL: ", service.url)
+		log.Info("Unable to parse the URL: " + service.url)
 	}
 
 	if url.Scheme == "https" {
@@ -182,7 +182,7 @@ func (service *PingdomMonitorService) addConfigToHttpCheck(httpCheck *pingdom.Ht
 		userIdsStringArray := strings.Split(providerConfig.AlertContacts, "-")
 
 		if userIds, err := util.SliceAtoi(userIdsStringArray); err != nil {
-			log.Info("Error decoding user alert contact IDs from config", err.Error())
+			log.Info("Error decoding user alert contact IDs from config" + err.Error())
 		} else {
 			httpCheck.UserIds = userIds
 		}
@@ -192,7 +192,7 @@ func (service *PingdomMonitorService) addConfigToHttpCheck(httpCheck *pingdom.Ht
 		integrationIdsStringArray := strings.Split(providerConfig.AlertIntegrations, "-")
 
 		if integrationIds, err := util.SliceAtoi(integrationIdsStringArray); err != nil {
-			log.Info("Error decoding integration ids into integers", err.Error())
+			log.Info("Error decoding integration ids into integers" + err.Error())
 		} else {
 			httpCheck.IntegrationIds = integrationIds
 		}
@@ -202,7 +202,7 @@ func (service *PingdomMonitorService) addConfigToHttpCheck(httpCheck *pingdom.Ht
 		integrationTeamIdsStringArray := strings.Split(providerConfig.TeamAlertContacts, "-")
 
 		if integrationTeamIdsStringArray, err := util.SliceAtoi(integrationTeamIdsStringArray); err != nil {
-			log.Info("Error decoding integration ids into integers", err.Error())
+			log.Info("Error decoding integration ids into integers" + err.Error())
 		} else {
 			httpCheck.TeamIds = integrationTeamIdsStringArray
 		}
@@ -245,14 +245,14 @@ func (service *PingdomMonitorService) addConfigToHttpCheck(httpCheck *pingdom.Ht
 
 	if providerConfig != nil && len(providerConfig.ShouldContain) > 0 {
 		httpCheck.ShouldContain = providerConfig.ShouldContain
-		log.Info("Should contain detected. Setting Should Contain string: ", providerConfig.ShouldContain)
+		log.Info("Should contain detected. Setting Should Contain string: " + providerConfig.ShouldContain)
 	}
 
 	// Tags should be a single word or multiple comma-seperated words
 	if providerConfig != nil && len(providerConfig.Tags) > 0 {
 		if !strings.Contains(providerConfig.Tags, " ") {
 			httpCheck.Tags = providerConfig.Tags
-			log.Info("Tags detected. Setting Tags as: ", providerConfig.Tags)
+			log.Info("Tags detected. Setting Tags as: " + providerConfig.Tags)
 		} else {
 			log.Info("Tag string should not contain spaces. Not applying tags.")
 		}

--- a/pkg/monitors/updown/updown-monitor.go
+++ b/pkg/monitors/updown/updown-monitor.go
@@ -111,13 +111,13 @@ func (service *UpdownMonitorService) Add(updownMonitor models.Monitor) {
 	log.Info("Monitor addition request has been completed")
 
 	if (httpResponse.StatusCode == http.StatusCreated) && (err == nil) {
-		log.Info("Monitor %s has been added.", updownMonitor.Name)
+		log.Info(fmt.Sprintf("Monitor %s has been added.", updownMonitor.Name))
 
 	} else if (httpResponse.StatusCode == http.StatusBadRequest) && (err != nil) {
-		log.Info("Monitor %s is not created because of invalid parameters or it exists.", updownMonitor.Name)
+		log.Info(fmt.Sprintf("Monitor %s is not created because of invalid parameters or it exists.", updownMonitor.Name))
 
 	} else {
-		log.Info("Unable to create monitor %s ", updownMonitor.Name)
+		log.Info(fmt.Sprintf("Unable to create monitor %s ", updownMonitor.Name))
 
 	}
 
@@ -137,7 +137,7 @@ func (updownService *UpdownMonitorService) createHttpCheck(updownMonitor models.
 	_, err := url.Parse(updownMonitor.URL)
 
 	if err != nil {
-		log.Info("Unable to parse the URL : ", updownMonitor.URL)
+		log.Info("Unable to parse the URL : " + updownMonitor.URL)
 		return updownCheckItemObj
 	}
 
@@ -191,10 +191,10 @@ func (service *UpdownMonitorService) Update(updownMonitor models.Monitor) {
 	log.Info("Updown's check Update request has been completed")
 
 	if (httpResponse.StatusCode == http.StatusOK) && (err == nil) {
-		log.Info("Monitor %s has been updated with following parameters", updownMonitor.Name)
+		log.Info(fmt.Sprintf("Monitor %s has been updated with following parameters", updownMonitor.Name))
 
 	} else {
-		log.Info("Monitor %s is not updated because of %s", updownMonitor.Name, err.Error())
+		log.Info(fmt.Sprintf("Monitor %s is not updated because of %s", updownMonitor.Name, err.Error()))
 
 	}
 
@@ -209,13 +209,13 @@ func (updownService *UpdownMonitorService) Remove(updownMonitor models.Monitor) 
 	log.Info("Updown's check Remove request has been completed")
 
 	if (httpResponse.StatusCode == http.StatusOK) && (err == nil) {
-		log.Info("Monitor %v has been deleted.", updownMonitor.Name)
+		log.Info(fmt.Sprintf("Monitor %v has been deleted.", updownMonitor.Name))
 
 	} else if (httpResponse.StatusCode == http.StatusNotFound) && (err != nil) {
-		log.Info("Monitor %v is not found.", updownMonitor.Name)
+		log.Info(fmt.Sprintf("Monitor %v is not found.", updownMonitor.Name))
 
 	} else {
-		log.Info("Unable to delete %v monitor: ", updownMonitor.Name)
+		log.Info("Unable to delete %v monitor: " + updownMonitor.Name)
 	}
 
 }

--- a/pkg/monitors/uptime/uptime-monitor.go
+++ b/pkg/monitors/uptime/uptime-monitor.go
@@ -37,7 +37,7 @@ func (monitor *UpTimeMonitorService) Equal(oldMonitor models.Monitor, newMonitor
 	// using processed config to avoid unnecessary update call because of default values
 	// like contacts and sorted locations
 	if !(reflect.DeepEqual(processProviderConfig(oldMonitor), processProviderConfig(newMonitor))) {
-		log.Info("There are some new changes in %s monitor", newMonitor.Name)
+		log.Info(fmt.Sprintf("There are some new changes in %s monitor", newMonitor.Name))
 		return false
 	}
 	return true
@@ -92,7 +92,7 @@ func (monitor *UpTimeMonitorService) GetAll() []models.Monitor {
 
 		err := json.Unmarshal(response.Bytes, &f)
 		if err != nil {
-			log.Info("Could not Unmarshal Json Response with error: %v", err)
+			log.Info(fmt.Sprintf("Could not Unmarshal Json Response with error: %v", err))
 		}
 		monitors = append(monitors, f.Monitors...)
 		pageNo++


### PR DESCRIPTION
After the change to use the log package `sigs.k8s.io/controller-runtime/pkg/log` (Ref: https://github.com/stakater/IngressMonitorController/commit/c9c426f51ffd1737370137cb50034063fa53bf51), logging across various areas results in errors like `odd number of arguments passed as key-value pairs for logging`.

A couple have already been fixed in previous PR's (#342 & #343), but we keep hitting the error in other places. 

I've done a full sweep of the codebase and fixed any mentions of the previous format. 

I was unable to run the tests locally as I don't have the appropriate configs, but I'm able to build successfully. 