### PR TITLE
fix default tag for kube rbac proxy image

### DIFF
--- a/charts/ingressmonitorcontroller/values.yaml
+++ b/charts/ingressmonitorcontroller/values.yaml
@@ -13,7 +13,7 @@ imagePullSecrets: []
 kube-rbac-proxy:
   image:
     repository: gcr.io/kubebuilder/kube-rbac-proxy
-    tag: v2.1.8
+    tag: v0.8.0
     pullPolicy: IfNotPresent
 
 # Partial override for ingress-monitor-controller.fullname template (will keep the release name)


### PR DESCRIPTION
Fixes #350 