### PR TITLE
Add control over ssl checks on Pingdom

### DIFF
--- a/api/v1alpha1/endpointmonitor_types.go
+++ b/api/v1alpha1/endpointmonitor_types.go
@@ -259,6 +259,19 @@ type PingdomConfig struct {
 	// `-` separated team id's (e.g. "1234567_8_9-9876543_2_1")
 	// +optional
 	TeamAlertContacts string `json:"teamAlertContacts,omitempty"`
+
+	// Monitor SSL/TLS certificate
+	// Monitor the validity of your SSL/TLS certificate. With this enabled Uptime checks will be considered DOWN when
+	// the certificate becomes invalid or expires.
+	// SSL/TLS certificate monitoring is available for HTTP checks.
+	// +optional
+	VerifyCertificate bool `json:"verifyCertificate,omitempty"`
+
+	// Consider down prior to certificate expiring
+	// Select the number of days prior to your certificate expiry date that you want to consider the check down.
+	// At this day your check will be considered down and if applicable a down alert will be sent.
+	// +optional
+	SSLDownDaysBefore int `json:"sslDownDaysBefore,omitempty"`
 }
 
 // AppInsightsConfig defines the configuration for AppInsights Monitor Provider

--- a/pkg/monitors/pingdom/pingdom-monitor.go
+++ b/pkg/monitors/pingdom/pingdom-monitor.go
@@ -258,6 +258,19 @@ func (service *PingdomMonitorService) addConfigToHttpCheck(httpCheck *pingdom.Ht
 		}
 	}
 
+	// Enable SSL validation
+	if providerConfig != nil {
+		httpCheck.VerifyCertificate = &providerConfig.VerifyCertificate
+	}
+
+	// Set certificate not valid before, default to 28 days to accommodate Let's Encrypt 30 day renewals + 2 days grace period.
+	defaultSSLDownDaysBefore := 28
+	if providerConfig != nil && providerConfig.SSLDownDaysBefore > 0 {
+		httpCheck.SSLDownDaysBefore = &providerConfig.SSLDownDaysBefore
+	} else {
+		httpCheck.SSLDownDaysBefore = &defaultSSLDownDaysBefore
+	}
+
 	if providerConfig != nil {
 		httpCheck.Paused = providerConfig.Paused
 		httpCheck.NotifyWhenBackup = providerConfig.NotifyWhenBackUp

--- a/pkg/monitors/pingdom/pingdom-monitor_test.go
+++ b/pkg/monitors/pingdom/pingdom-monitor_test.go
@@ -1,6 +1,7 @@
 package pingdom
 
 import (
+	"net/url"
 	"testing"
 
 	"github.com/stakater/IngressMonitorController/pkg/config"
@@ -28,12 +29,16 @@ func TestAddMonitorWithCorrectValues(t *testing.T) {
 	if err != nil {
 		t.Error("Error: " + err.Error())
 	}
-	if mRes.Name != m.Name || mRes.URL != m.URL {
-		t.Error("URL and name should be the same")
+
+	// Pingdom returns the hostname only without prefix
+	mURL, _ := url.Parse(m.URL)
+	if mRes.Name != m.Name || mRes.URL != mURL.Host {
+		t.Errorf("URL and name should be the same. request: %+v response: %+v", m, mRes)
 	}
+
+	// Cleanup
 	service.Remove(*mRes)
 	monitor, err := service.GetByName(mRes.Name)
-
 	if monitor != nil {
 		t.Error("Monitor should've been deleted ", monitor, err)
 	}
@@ -53,6 +58,7 @@ func TestUpdateMonitorWithCorrectValues(t *testing.T) {
 	}
 	service.Setup(*provider)
 
+	// Create initial record
 	m := models.Monitor{Name: "google-test", URL: "https://google.com"}
 	service.Add(m)
 
@@ -61,27 +67,30 @@ func TestUpdateMonitorWithCorrectValues(t *testing.T) {
 	if err != nil {
 		t.Error("Error: " + err.Error())
 	}
-	if mRes.Name != m.Name || mRes.URL != m.URL {
-		t.Error("URL and name should be the same")
+
+	// Pingdom returns the hostname only without prefix
+	mURL, _ := url.Parse(m.URL)
+	if mRes.Name != m.Name || mRes.URL != mURL.Host {
+		t.Errorf("URL and name should be the same. request: %+v response: %+v", m, mRes)
 	}
 
+	// Update the record
 	mRes.URL = "https://facebook.com"
 
 	service.Update(*mRes)
 
 	mRes, err = service.GetByName("google-test")
-
 	if err != nil {
 		t.Error("Error: " + err.Error())
 	}
-	if mRes.URL != "https://facebook.com" {
-		t.Error("URL and name should be the same")
+
+	if mRes.Name != m.Name || mRes.URL != "facebook.com" {
+		t.Errorf("URL and name should be the same. request: %+v response: %+v", m, mRes)
 	}
 
+	// Cleanup
 	service.Remove(*mRes)
-
 	monitor, err := service.GetByName(mRes.Name)
-
 	if monitor != nil {
 		t.Error("Monitor should've been deleted ", monitor, err)
 	}


### PR DESCRIPTION
- Adding `VerifyCertificate` (default to `false`) and `SSLDownDaysBefore` (default to `28` days) vars to control monitoring of certificates
- Fix tests failing due to mismatch of request URL is with a scheme and returned is without.