### PR TITLE
[release-v1] Remove monitor only when annotation is set to false

### DIFF
--- a/pkg/controller/actions.go
+++ b/pkg/controller/actions.go
@@ -55,7 +55,6 @@ func (r ResourceUpdatedAction) handle(c *MonitorController) error {
 		}
 
 	} else {
-		c.removeMonitorsIfExist(oldMonitorName)
 		log.Info("Not doing anything with this ingress because no annotation exists with name: " + constants.MonitorEnabledAnnotation)
 	}
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -2,6 +2,8 @@ package controller
 
 import (
 	"fmt"
+	"time"
+
 	routev1 "github.com/openshift/api/route/v1"
 	log "github.com/sirupsen/logrus"
 	"github.com/stakater/IngressMonitorController/pkg/callbacks"
@@ -20,7 +22,6 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
-	"time"
 )
 
 // MonitorController which can be used for monitoring ingresses

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -162,7 +162,10 @@ func (c *MonitorController) removeMonitorsIfExist(monitorName string) {
 }
 
 func (c *MonitorController) removeMonitorIfExists(monitorService monitors.MonitorServiceProxy, monitorName string) {
-	m, _ := monitorService.GetByName(monitorName)
+	m, err := monitorService.GetByName(monitorName)
+	if err != nil {
+		log.Println(err)
+	}
 
 	if m != nil { // Monitor Exists
 		monitorService.Remove(*m) // Remove the monitor
@@ -179,7 +182,10 @@ func (c *MonitorController) createOrUpdateMonitors(monitorName string, oldMonito
 }
 
 func (c *MonitorController) createOrUpdateMonitor(monitorService monitors.MonitorServiceProxy, monitorName string, oldMonitorName string, monitorURL string, annotations map[string]string) {
-	m, _ := monitorService.GetByName(oldMonitorName)
+	m, err := monitorService.GetByName(oldMonitorName)
+	if err != nil {
+		log.Println(err)
+	}
 
 	if m != nil { // Monitor Already Exists
 		log.Info("Monitor already exists for ingress: " + monitorName)

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -164,7 +164,7 @@ func (c *MonitorController) removeMonitorsIfExist(monitorName string) {
 func (c *MonitorController) removeMonitorIfExists(monitorService monitors.MonitorServiceProxy, monitorName string) {
 	m, err := monitorService.GetByName(monitorName)
 	if err != nil {
-		log.Println(err)
+		log.Info(err)
 	}
 
 	if m != nil { // Monitor Exists
@@ -184,7 +184,7 @@ func (c *MonitorController) createOrUpdateMonitors(monitorName string, oldMonito
 func (c *MonitorController) createOrUpdateMonitor(monitorService monitors.MonitorServiceProxy, monitorName string, oldMonitorName string, monitorURL string, annotations map[string]string) {
 	m, err := monitorService.GetByName(oldMonitorName)
 	if err != nil {
-		log.Println(err)
+		log.Info(err)
 	}
 
 	if m != nil { // Monitor Already Exists

--- a/pkg/monitors/pingdom/pingdom-monitor.go
+++ b/pkg/monitors/pingdom/pingdom-monitor.go
@@ -3,11 +3,12 @@ package pingdom
 import (
 	"encoding/json"
 	"fmt"
-	log "github.com/sirupsen/logrus"
 	"net/url"
 	"os"
 	"strconv"
 	"strings"
+
+	log "github.com/sirupsen/logrus"
 
 	"github.com/russellcardullo/go-pingdom/pingdom"
 	"github.com/stakater/IngressMonitorController/pkg/config"
@@ -56,7 +57,7 @@ func (service *PingdomMonitorService) GetByName(name string) (*models.Monitor, e
 
 	monitors := service.GetAll()
 	for _, mon := range monitors {
-		if mon.Name == name {
+		if strings.EqualFold(mon.Name, name) {
 			return &mon, nil
 		}
 	}
@@ -135,25 +136,25 @@ func (service *PingdomMonitorService) createHttpCheck(monitor models.Monitor) pi
 	httpCheck.Url = url.Path
 	httpCheck.Name = monitor.Name
 
-    if service.alertContacts != "" {
-    	userIdsStringArray := strings.Split(service.alertContacts, "-")
-    
-    	if userIds, err := util.SliceAtoi(userIdsStringArray); err != nil {
-    		log.Println(err.Error())
-    	} else {
-    		httpCheck.UserIds = userIds
-    	}
-    }
+	if service.alertContacts != "" {
+		userIdsStringArray := strings.Split(service.alertContacts, "-")
 
-    if service.alertIntegrations != "" {
-    	integrationIdsStringArray := strings.Split(service.alertIntegrations, "-")
-    
-    	if integrationIds, err := util.SliceAtoi(integrationIdsStringArray); err != nil {
-    		log.Println(err.Error())
-    	} else {
-    		httpCheck.IntegrationIds = integrationIds
-    	}
-    }
+		if userIds, err := util.SliceAtoi(userIdsStringArray); err != nil {
+			log.Println(err.Error())
+		} else {
+			httpCheck.UserIds = userIds
+		}
+	}
+
+	if service.alertIntegrations != "" {
+		integrationIdsStringArray := strings.Split(service.alertIntegrations, "-")
+
+		if integrationIds, err := util.SliceAtoi(integrationIdsStringArray); err != nil {
+			log.Println(err.Error())
+		} else {
+			httpCheck.IntegrationIds = integrationIds
+		}
+	}
 	service.addAnnotationConfigToHttpCheck(&httpCheck, monitor.Annotations)
 
 	return httpCheck


### PR DESCRIPTION
When an ingress/route doesn't have annotation ```monitor.stakater.com/enabled``` set to `true`,  really don't do anything at all. I find this action would spam a lot if there are just small amount of ingress that have monitor annotations compared to total of ingresses in all namespaces..

And also applied go fmt for clarity.