### PR TITLE
Not setting SSLDownDaysBefore when VerifyCertificate is false

### DIFF
--- a/pkg/monitors/pingdom/pingdom-monitor.go
+++ b/pkg/monitors/pingdom/pingdom-monitor.go
@@ -265,10 +265,13 @@ func (service *PingdomMonitorService) addConfigToHttpCheck(httpCheck *pingdom.Ht
 
 	// Set certificate not valid before, default to 28 days to accommodate Let's Encrypt 30 day renewals + 2 days grace period.
 	defaultSSLDownDaysBefore := 28
-	if providerConfig != nil && providerConfig.SSLDownDaysBefore > 0 {
-		httpCheck.SSLDownDaysBefore = &providerConfig.SSLDownDaysBefore
-	} else {
-		httpCheck.SSLDownDaysBefore = &defaultSSLDownDaysBefore
+	// Pingdom doesn't allow SSLDownDaysBefore to be set if VerifyCertificate isn't set to true
+	if providerConfig != nil && providerConfig.VerifyCertificate {
+		if providerConfig.SSLDownDaysBefore > 0 {
+			httpCheck.SSLDownDaysBefore = &providerConfig.SSLDownDaysBefore
+		} else {
+			httpCheck.SSLDownDaysBefore = &defaultSSLDownDaysBefore
+		}
 	}
 
 	if providerConfig != nil {


### PR DESCRIPTION
This is to address Pingdom error:
```
"Error updating Monitor: 400 Bad Request: Parameter `ssl_down_days_before` requires `verify_certificate` to be active"
```

Fixes: https://github.com/stakater/IngressMonitorController/issues/367