### PR TITLE
fix: statuscake response parse error

### DIFF
--- a/pkg/monitors/statuscake/statuscake-responses.go
+++ b/pkg/monitors/statuscake/statuscake-responses.go
@@ -21,7 +21,7 @@ type StatusCakeMonitorData struct {
 	ContactGroup []string `json:"contact_groups"`
 	Status       string   `json:"status"`
 	Tags         []string `json:"tags"`
-	Uptime       int      `json:"uptime"`
+	Uptime       float64  `json:"uptime"`
 }
 type StatusCakeMonitorMetadata struct {
 	Page       int `json:"page"`


### PR DESCRIPTION
On our production IMC fails to parse the response from statuscake because it tries to parse the uptime into an int. This works fine for most tests because it will be either 0 or 100, but in prod we get errors like:

` {“level”:“error”,“ts”:1669416334.742954,“logger”:“statuscake-monitor”,“msg”:“Failed to unmarshal response”,“error”:“json: cannot unmarshal number 99.35 into Go struct field StatusCakeMonitorData.data.uptime of type int”,“`
