### PR TITLE
fix(helm): add missing keys for securityContexts

### DIFF
--- a/charts/ingressmonitorcontroller/README.md
+++ b/charts/ingressmonitorcontroller/README.md
@@ -32,6 +32,7 @@ helm install stakater/ingressmonitorcontroller
 | kube-rbac-proxy.image.repository             | `gcr.io/kubebuilder/kube-rbac-proxy`                              | Image repository for kube-rbac-proxy                                                                      |
 | kube-rbac-proxy.image.tag            | `v0.8.0`                              | Tag of the kube-rbac-proxy image                                                                      |
 | kube-rbac-proxy.image.pullPolicy             | `IfNotPresent`                              | Pull policy for the image                                                                      |
+| kube-rbac-proxy.securityContext             | `{}`                              |securityContext for the kube-rbac-proxy Container                                                                      |
 | imagePullSecrets             | ``                                    | List of secrets used to pull images                                                            |
 | nameOverride                 | `""`                                  | Partial override for ingress-monitor-controller.fullname template (will keep the release name) |
 | fullnameOverride             | `""`                                  | Full override for ingress-monitor-controller.fullname template                                 |

--- a/charts/ingressmonitorcontroller/templates/deployment.yaml
+++ b/charts/ingressmonitorcontroller/templates/deployment.yaml
@@ -40,7 +40,9 @@ spec:
         - containerPort: 8443
           name: https
         resources: 
-          {{- toYaml .resources | nindent 10 }}       
+          {{- toYaml .resources | nindent 10 }}
+        securityContext:
+          {{- toYaml .securityContext | nindent 10 }}  
       {{- end }}    
       - args:
         - --health-probe-bind-address=:8081
@@ -77,6 +79,8 @@ spec:
           periodSeconds: 10
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
+        securityContext:
+          {{- toYaml .Values.securityContext | nindent 10 }}  
       terminationGracePeriodSeconds: 10
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/ingressmonitorcontroller/values.yaml
+++ b/charts/ingressmonitorcontroller/values.yaml
@@ -19,6 +19,14 @@ kube-rbac-proxy:
     pullPolicy: IfNotPresent
   resources: 
     {}
+  securityContext:
+    {}
+    # capabilities:
+    #   drop:
+    #   - ALL
+    # readOnlyRootFilesystem: true
+    # runAsNonRoot: true
+    # runAsUser: 1000
 
 # Partial override for ingress-monitor-controller.fullname template (will keep the release name)
 nameOverride: ""


### PR DESCRIPTION
## Problem
In the values you can set the securityContext on container level, but the corresponding key is missing in the deployment.

The setting of the securityContext for the kube-rbac-proxy container has also been added.

## Solution
Optionally, the securityCotext for the manager and kube-rbac-proxy container can be set.