### PR TITLE
StatusCake: Use regions instead of node_locations

### DIFF
--- a/api/v1alpha1/endpointmonitor_types.go
+++ b/api/v1alpha1/endpointmonitor_types.go
@@ -197,7 +197,7 @@ type StatusCakeConfig struct {
 
 	// Comma separated list of Node Location IDs
 	// +optional
-	NodeLocations string `json:"nodeLocations,omitempty"`
+	Regions string `json:"regions,omitempty"`
 
 	// Comma separated list of HTTP codes to trigger error on
 	// +optional

--- a/bundle/manifests/endpointmonitor.stakater.com_endpointmonitors.yaml
+++ b/bundle/manifests/endpointmonitor.stakater.com_endpointmonitors.yaml
@@ -152,8 +152,8 @@ spec:
                   followRedirect:
                     description: Enable ingress redirects
                     type: boolean
-                  nodeLocations:
-                    description: Comma separated list of Node Location IDs
+                  regions:
+                    description: Comma separated list of regions.
                     type: string
                   paused:
                     description: Pause the service

--- a/charts/ingressmonitorcontroller/Chart.yaml
+++ b/charts/ingressmonitorcontroller/Chart.yaml
@@ -3,10 +3,10 @@ name: ingressmonitorcontroller
 description: IngressMonitorController Operator chart that runs on kubernetes
 
 # Helm chart Version
-version: 2.1.44
+version: 2.1.45
 
 # Application version to be deployed
-appVersion: 2.1.44
+appVersion: 2.1.45
 
 keywords:
   - IngressMonitorController

--- a/charts/ingressmonitorcontroller/crds/endpointmonitor.stakater.com_endpointmonitors.yaml
+++ b/charts/ingressmonitorcontroller/crds/endpointmonitor.stakater.com_endpointmonitors.yaml
@@ -153,8 +153,8 @@ spec:
                   followRedirect:
                     description: Enable ingress redirects
                     type: boolean
-                  nodeLocations:
-                    description: Comma separated list of Node Location IDs
+                  regions:
+                    description: Comma separated list of regions.
                     type: string
                   paused:
                     description: Pause the service

--- a/charts/ingressmonitorcontroller/values.yaml
+++ b/charts/ingressmonitorcontroller/values.yaml
@@ -8,7 +8,7 @@ replicaCount: 1
 
 image:
   repository: stakater/ingressmonitorcontroller
-  tag: v2.1.44
+  tag: v2.1.45
   pullPolicy: IfNotPresent
 imagePullSecrets: []
 
@@ -17,7 +17,7 @@ kube-rbac-proxy:
     repository: gcr.io/kubebuilder/kube-rbac-proxy
     tag: v0.8.0
     pullPolicy: IfNotPresent
-  resources: 
+  resources:
     {}
   securityContext:
     {}

--- a/config/crd/bases/endpointmonitor.stakater.com_endpointmonitors.yaml
+++ b/config/crd/bases/endpointmonitor.stakater.com_endpointmonitors.yaml
@@ -153,9 +153,6 @@ spec:
                   followRedirect:
                     description: Enable ingress redirects
                     type: boolean
-                  nodeLocations:
-                    description: Comma separated list of Node Location IDs
-                    type: string
                   paused:
                     description: Pause the service
                     type: boolean
@@ -168,6 +165,9 @@ spec:
                   realBrowser:
                     description: Enable Real Browser
                     type: boolean
+                  regions:
+                    description: Comma separated list of Node Location IDs
+                    type: string
                   statusCodes:
                     description: Comma separated list of HTTP codes to trigger error
                       on

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: stakater/ingressmonitorcontroller
-  newTag: v2.1.44
+  newTag: v2.1.45

--- a/docs/statuscake-configuration.md
+++ b/docs/statuscake-configuration.md
@@ -1,7 +1,7 @@
 # StatusCake Configuration
 
 ## Basic
-The following properties need to be configured for Statuscake, in addition to the general properties listed 
+The following properties need to be configured for Statuscake, in addition to the general properties listed
  in the [Configuration section of the README](../README.md#configuration):
 
 | Key      | Description                                         |
@@ -25,15 +25,16 @@ Currently additional Statuscake configurations can be added through these fields
 | TestTags                | Comma separated list of tags                     |
 | FindString              | String to look for within the response           |
 | BasicAuthUser          | Required for [basic-authenticationchecks](#basic-auth-checks)  |
+| Regions                 | Regions to execute the check from                |
 
 
 ### Basic Auth checks
 
 Statuscake supports checks completing basic auth requirements. In `EndpointMonitor` the field `basicAuthUser` can be used to trigger the Ingress Monitor attempting to configure this setting. The value of the field should be the *username* to be configured. The Ingress Monitor Controller will then attempt to access an OS env variable of the same name which will return the *password* that should be used. The env variable can be mounted within the Ingress Monitor Controller container via a secret.
 
-For example; setting the field like `basic-auth-user: 'my-service-username'` will set the username field to the value `my-service-username` and will retrieve the password via `os.Getenv('my-service-username')` and set this appropriately. 
+For example; setting the field like `basic-auth-user: 'my-service-username'` will set the username field to the value `my-service-username` and will retrieve the password via `os.Getenv('my-service-username')` and set this appropriately.
 
-## Example: 
+## Example:
 
 ```yaml
 apiVersion: endpointmonitor.stakater.com/v1alpha1

--- a/examples/endpointMonitor/statuscake-config.yaml
+++ b/examples/endpointMonitor/statuscake-config.yaml
@@ -19,4 +19,5 @@ spec:
     triggerRate: 1
     pingUrl: 'https://stakater2.com/'
     contactGroup: '123456,654321'
+    regions: amsterdam, stockholm
   url: 'https://stakater1.com/'

--- a/pkg/monitors/statuscake/statuscake-monitor.go
+++ b/pkg/monitors/statuscake/statuscake-monitor.go
@@ -79,6 +79,13 @@ func buildUpsertForm(m models.Monitor, cgroup string) url.Values {
 		}
 	}
 
+	if providerConfig != nil && len(providerConfig.Regions) > 0 {
+		regions := convertStringToArray(providerConfig.Regions)
+		for _, region := range regions {
+			f.Add("regions[]", region)
+		}
+	}
+
 	if providerConfig != nil && len(providerConfig.BasicAuthUser) > 0 {
 		// This value is mandatory
 		// Environment variable should define the password


### PR DESCRIPTION
Hi, as described in #540 setting nodeLocations didn't have any affect.

Thanks to the response of @MuneebAijaz I was able to track down the required changes.

I was able to build the IngressMonitorController locally, and after deploying my tag to Kubernetes, the regions were set correctly again.