### PR TITLE
Updates go version in release GA

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - "v*"
 
 env:
-  GOLANG_VERSION: 1.18
+  GOLANG_VERSION: 1.21
 
 jobs:
   build:


### PR DESCRIPTION
The release workflow is not running because of wrong go version..