### PR TITLE
For grafana monitor, fixes bug with invalid tenant ID

### DIFF
--- a/pkg/monitors/grafana/grafana-monitor_test.go
+++ b/pkg/monitors/grafana/grafana-monitor_test.go
@@ -25,19 +25,24 @@ func TestAddMonitorWithCorrectValues(t *testing.T) {
 		return
 	}
 	service.Setup(*provider)
+
 	m := models.Monitor{Name: "google-test", URL: "https://google.com"}
+	preExistingMonitor, _ := service.GetByName(m.Name)
+
+	if preExistingMonitor != nil {
+		service.Remove(*preExistingMonitor)
+	}
+
+	previousResources := len(service.GetAll())
 	service.Add(m)
 
 	mRes := service.GetAll()
 
-	if len(mRes) == 0 {
+	if len(mRes) == previousResources {
 		t.Errorf("Found empty response for Monitor. Name: %s and URL: %s", m.Name, m.URL)
 	}
-	if len(mRes) > 1 {
+	if len(mRes) > previousResources+1 {
 		t.Errorf("Found too many response for Monitor, %v, after add.", len(mRes))
-	}
-	if mRes[0].Name != m.Name || mRes[0].URL != m.URL {
-		t.Error("URL and name should be the same", mRes[0], m)
 	}
 
 	monitor, err := service.GetByName(m.Name)
@@ -45,7 +50,10 @@ func TestAddMonitorWithCorrectValues(t *testing.T) {
 	if err != nil {
 		t.Error("Monitor should've been found", monitor, err)
 	}
-	service.Remove(mRes[0])
+	if monitor.Name != m.Name || monitor.URL != m.URL {
+		t.Error("URL and name should be the same", monitor, m)
+	}
+	service.Remove(*monitor)
 
 	monitor, err = service.GetByName(m.Name)
 
@@ -62,38 +70,56 @@ func TestUpdateMonitorWithCorrectValues(t *testing.T) {
 		return
 	}
 	service.Setup(*provider)
+
 	m := models.Monitor{Name: "google-test", URL: "https://google.com"}
+	preExistingMonitor, _ := service.GetByName(m.Name)
+
+	if preExistingMonitor != nil {
+		service.Remove(*preExistingMonitor)
+	}
+
+	previousResources := len(service.GetAll())
 	service.Add(m)
 
 	mRes := service.GetAll()
 
-	if len(mRes) == 0 {
+	if len(mRes) == previousResources {
 		t.Errorf("Found empty response for Monitor. Name: %s and URL: %s", m.Name, m.URL)
 	}
-	if len(mRes) > 1 {
+	if len(mRes) > previousResources+1 {
 		t.Errorf("Found too many response for Monitor, %v, after add.", len(mRes))
 	}
-	m2 := models.Monitor{Name: "stakater-test", URL: "https://stakater.com", ID: mRes[0].ID, Config: mRes[0].Config}
+	monitor, err := service.GetByName(m.Name)
+	if err != nil || monitor == nil {
+		t.Error("Monitor should've been found", monitor, err)
+	}
+	if monitor.Name != m.Name || monitor.URL != m.URL {
+		t.Error("URL and name should be the same", monitor, m)
+	}
+	m2 := models.Monitor{Name: "stakater-test", URL: "https://stakater.com", ID: monitor.ID, Config: monitor.Config}
 	service.Update(m2)
 
 	mRes2 := service.GetAll()
 
-	if len(mRes2) == 0 {
+	if len(mRes2) == previousResources {
 		t.Errorf("Found empty response for Monitor. Name: %s and URL: %s", m2.Name, m2.URL)
 	}
-	if len(mRes2) > 1 {
+	if len(mRes2) > previousResources+1 {
 		t.Errorf("Found too many response for Monitor, %v, after update.", len(mRes2))
 	}
-	if mRes2[0].Name != m2.Name || mRes2[0].URL != m2.URL {
-		t.Error("URL and name should be the same", mRes2[0], m2)
-	}
 
-	monitor, err := service.GetByName(m.Name)
-
-	if monitor != nil {
+	monitor1, _ := service.GetByName(m.Name)
+	if monitor1 != nil {
 		t.Error("Monitor should not exist since it was updated", monitor, err)
 	}
-	service.Remove(mRes2[0])
+	monitor2, err := service.GetByName(m2.Name)
+	if err != nil {
+		t.Error("Monitor should've been found", monitor, err)
+	}
+	if monitor2.Name != m2.Name || monitor2.URL != m2.URL {
+		t.Error("URL and name should be the same", monitor2, m2)
+	}
+	service.Remove(*monitor2)
 
 	monitor, err = service.GetByName(m2.Name)
 


### PR DESCRIPTION
There was an issue with Grafana synthetic monitoring which resulted in these errors:
```
{"level":"error","ts":1704550886.2006788,"logger":"gcloud-monitor","msg":"Failed to update monitor","error":"check update request: status=\"400 Bad Request\", msg=\"Invalid tenantId for user\", err=\"bad request\"","stacktrace":"github.com/stakater/IngressMonitorController/v2/pkg/monitors/grafana.(*GrafanaMonitorService).Update\n\t/workspace/pkg/monitors/grafana/grafana-monitor.go:146\ngithub.com/stakater/IngressMonitorController/v2/pkg/monitors.(*MonitorServiceProxy).Update\n\t/workspace/pkg/monitors/monitor-proxy.go:101\ngithub.com/stakater/IngressMonitorController/v2/pkg/controllers.(*EndpointMonitorReconciler).handleUpdate\n\t/workspace/pkg/controllers/endpointmonitor_updated.go:26\ngithub.com/stakater/IngressMonitorController/v2/pkg/controllers.
```

The reason was that tenant was picked from config when it should be picked from the actual check