### PR TITLE
chore: fix kustomize build step

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,7 +160,7 @@ KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/k
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
 $(KUSTOMIZE): $(LOCALBIN)
-	curl -s $(KUSTOMIZE_INSTALL_SCRIPT) | bash -s -- $(subst v,,$(KUSTOMIZE_VERSION)) $(LOCALBIN)
+	@[ -f $(LOCALBIN)/kustomize ] || curl -s $(KUSTOMIZE_INSTALL_SCRIPT) | bash -s -- $(subst v,,$(KUSTOMIZE_VERSION)) $(LOCALBIN)
 
 .PHONY: controller-gen
 controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary.

--- a/pkg/monitors/pingdomtransaction/pingdom-transaction-monitor_test.go
+++ b/pkg/monitors/pingdomtransaction/pingdom-transaction-monitor_test.go
@@ -48,8 +48,8 @@ func TestAddMonitorWithCorrectValues(t *testing.T) {
 
 	service.Setup(*provider)
 	m := models.Monitor{
-		Name: "google-test",
-		URL:  "https://google.com",
+		Name:   "google-test",
+		URL:    "https://google.com",
 		Config: spec,
 	}
 


### PR DESCRIPTION
Currently the pipeline fails on step `make bundle` with following error:
```
/home/runner/work/IngressMonitorController/IngressMonitorController/bin/kustomize exists. Remove it first.
```
This happened because the the updated version of envtest is now also installing kustomize.

We can just check if kustomize was installed in localbin folder first.