### PR TITLE
fix: tag in pull request gh action

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -109,7 +109,7 @@ jobs:
         build-args: BUILD_PARAMETERS=${{ env.BUILD_PARAMETERS }}
         platforms: linux/amd64,linux/arm,linux/arm64
         tags: |
-          ${{ env.GHCR_IMAGE_REPOSITORY }}:${{ steps.generate_tag.outputs.new_tag }}
+          ${{ env.GHCR_IMAGE_REPOSITORY }}:${{ steps.generate_tag.outputs.GIT_TAG }}
         labels: |
           org.opencontainers.image.source=${{ github.event.repository.clone_url }}
           org.opencontainers.image.created=${{ steps.prep.outputs.created }}


### PR DESCRIPTION
Hey @bnallapeta and @MuneebAijaz, I opened https://github.com/stakater/IngressMonitorController/pull/599 but the pull request workflow is failing because of a small bug: 

- The `Build and Push image to ghcr registry` step is using `${{ env.GHCR_IMAGE_REPOSITORY }}:${{ steps.generate_tag.outputs.new_tag }}` as tag. 
- However, the `generate_tag` step is not outputting `new_tag` but `GIT_TAG`
- Probably a copy paste error because the push workflow uses the `anothrNick/github-tag-action@1.61.0` github action for `generate_tag`, which in turn outputs `new_tag`. The pull request workflow instead uses some shell commands to generate the tag
- This was introduced in https://github.com/stakater/IngressMonitorController/pull/597. 

Could you please have a look? 

Once this is approved, I will update my other PR.