### PR TITLE
Statuscake: Add raw_post_data and user_agent

### DIFF
--- a/api/v1alpha1/endpointmonitor_types.go
+++ b/api/v1alpha1/endpointmonitor_types.go
@@ -228,6 +228,10 @@ type StatusCakeConfig struct {
 	// RawPostData can be used to send parameters within the URL. Changes the request from a GET to a POST
 	// +optional
 	RawPostData string `json:"rawPostData,omitempty"`
+
+  // UserAgent is used to set a user agent string.
+  // +optional
+  UserAgent string `json:"userAgent,omitempty"`
 }
 
 // PingdomConfig defines the configuration for Pingdom Monitor Provider

--- a/api/v1alpha1/endpointmonitor_types.go
+++ b/api/v1alpha1/endpointmonitor_types.go
@@ -229,9 +229,9 @@ type StatusCakeConfig struct {
 	// +optional
 	RawPostData string `json:"rawPostData,omitempty"`
 
-  // UserAgent is used to set a user agent string.
-  // +optional
-  UserAgent string `json:"userAgent,omitempty"`
+	// UserAgent is used to set a user agent string.
+	// +optional
+	UserAgent string `json:"userAgent,omitempty"`
 }
 
 // PingdomConfig defines the configuration for Pingdom Monitor Provider

--- a/api/v1alpha1/endpointmonitor_types.go
+++ b/api/v1alpha1/endpointmonitor_types.go
@@ -224,6 +224,10 @@ type StatusCakeConfig struct {
 	// String to look for within the response. Considered down if not found
 	// +optional
 	FindString string `json:"findString,omitempty"`
+
+	// RawPostData can be used to send parameters within the URL. Changes the request from a GET to a POST
+	// +optional
+	RawPostData string `json:"rawPostData,omitempty"`
 }
 
 // PingdomConfig defines the configuration for Pingdom Monitor Provider

--- a/charts/ingressmonitorcontroller/crds/endpointmonitor.stakater.com_endpointmonitors.yaml
+++ b/charts/ingressmonitorcontroller/crds/endpointmonitor.stakater.com_endpointmonitors.yaml
@@ -288,6 +288,10 @@ spec:
                   port:
                     description: TCP Port
                     type: integer
+                  rawPostData:
+                    description: RawPostData can be used to send parameters within
+                      the URL. Changes the request from a GET to a POST
+                    type: string
                   realBrowser:
                     description: Enable Real Browser
                     type: boolean
@@ -307,6 +311,9 @@ spec:
                   triggerRate:
                     description: Minutes to wait before sending an alert
                     type: integer
+                  userAgent:
+                    description: UserAgent is used to set a user agent string.
+                    type: string
                 type: object
               updownConfig:
                 description: Configuration for Updown Monitor Provider

--- a/config/crd/bases/endpointmonitor.stakater.com_endpointmonitors.yaml
+++ b/config/crd/bases/endpointmonitor.stakater.com_endpointmonitors.yaml
@@ -311,6 +311,9 @@ spec:
                   triggerRate:
                     description: Minutes to wait before sending an alert
                     type: integer
+                  userAgent:
+                    description: UserAgent is used to set a user agent string.
+                    type: string
                 type: object
               updownConfig:
                 description: Configuration for Updown Monitor Provider

--- a/config/crd/bases/endpointmonitor.stakater.com_endpointmonitors.yaml
+++ b/config/crd/bases/endpointmonitor.stakater.com_endpointmonitors.yaml
@@ -288,6 +288,10 @@ spec:
                   port:
                     description: TCP Port
                     type: integer
+                  rawPostData:
+                    description: RawPostData can be used to send parameters within
+                      the URL. Changes the request from a GET to a POST
+                    type: string
                   realBrowser:
                     description: Enable Real Browser
                     type: boolean

--- a/docs/statuscake-configuration.md
+++ b/docs/statuscake-configuration.md
@@ -26,6 +26,8 @@ Currently additional Statuscake configurations can be added through these fields
 | FindString              | String to look for within the response           |
 | BasicAuthUser          | Required for [basic-authenticationchecks](#basic-auth-checks)  |
 | Regions                 | Regions to execute the check from                |
+| RawPostData             | Add data to change the request to a POST         |
+| UserAgent               | Add a user agent string to the request           |
 
 
 ### Basic Auth checks

--- a/examples/endpointMonitor/statuscake-config.yaml
+++ b/examples/endpointMonitor/statuscake-config.yaml
@@ -20,4 +20,6 @@ spec:
     pingUrl: 'https://stakater2.com/'
     contactGroup: '123456,654321'
     regions: amsterdam, stockholm
+    rawPostData: '{"test": "data"}'
+    userAgent: test-user
   url: 'https://stakater1.com/'

--- a/pkg/monitors/statuscake/statuscake-monitor.go
+++ b/pkg/monitors/statuscake/statuscake-monitor.go
@@ -205,9 +205,9 @@ func buildUpsertForm(m models.Monitor, cgroup string) url.Values {
 	if providerConfig != nil && len(providerConfig.RawPostData) > 0 {
 		f.Add("post_raw", providerConfig.RawPostData)
 	}
-  if providerConfig != nil && len(providerConfig.UserAgent) > 0 {
-    f.Add("user_agent", providerConfig.UserAgent)
-  }
+  	if providerConfig != nil && len(providerConfig.UserAgent) > 0 {
+    		f.Add("user_agent", providerConfig.UserAgent)
+  	}
 	return f
 }
 

--- a/pkg/monitors/statuscake/statuscake-monitor.go
+++ b/pkg/monitors/statuscake/statuscake-monitor.go
@@ -202,6 +202,9 @@ func buildUpsertForm(m models.Monitor, cgroup string) url.Values {
 	if providerConfig != nil {
 		f.Add("find_string", providerConfig.FindString)
 	}
+	if providerConfig != nil && len(providerConfig.RawPostData) > 0 {
+		f.Add("post_raw", providerConfig.RawPostData)
+	}
 	return f
 }
 

--- a/pkg/monitors/statuscake/statuscake-monitor.go
+++ b/pkg/monitors/statuscake/statuscake-monitor.go
@@ -205,6 +205,9 @@ func buildUpsertForm(m models.Monitor, cgroup string) url.Values {
 	if providerConfig != nil && len(providerConfig.RawPostData) > 0 {
 		f.Add("post_raw", providerConfig.RawPostData)
 	}
+  if providerConfig != nil && len(providerConfig.UserAgent) > 0 {
+    f.Add("user_agent", providerConfig.UserAgent)
+  }
 	return f
 }
 


### PR DESCRIPTION
This PR adds some missing functionality. Specifically the ability to add raw post data and set a user client for the statuscake provider. 