### PR TITLE
Statuscake: Implement Equals function using TestTags

### DIFF
--- a/pkg/monitors/statuscake/statuscake-mappers.go
+++ b/pkg/monitors/statuscake/statuscake-mappers.go
@@ -1,7 +1,10 @@
 package statuscake
 
 import (
+	"strings"
+
 	statuscake "github.com/StatusCakeDev/statuscake-go"
+	endpointmonitorv1alpha1 "github.com/stakater/IngressMonitorController/v2/api/v1alpha1"
 	"github.com/stakater/IngressMonitorController/v2/pkg/models"
 )
 
@@ -11,6 +14,10 @@ func StatusCakeMonitorMonitorToBaseMonitorMapper(statuscakeData StatusCakeMonito
 	m.Name = statuscakeData.WebsiteName
 	m.URL = statuscakeData.WebsiteURL
 	m.ID = statuscakeData.TestID
+
+	var providerConfig endpointmonitorv1alpha1.StatusCakeConfig
+	providerConfig.TestTags = strings.Join(statuscakeData.Tags, ",")
+	m.Config = &providerConfig
 	return &m
 }
 
@@ -20,6 +27,10 @@ func StatusCakeApiResponseDataToBaseMonitorMapper(statuscakeData statuscake.Upti
 	m.Name = statuscakeData.Data.Name
 	m.URL = statuscakeData.Data.WebsiteURL
 	m.ID = statuscakeData.Data.ID
+
+	var providerConfig endpointmonitorv1alpha1.StatusCakeConfig
+	providerConfig.TestTags = strings.Join(statuscakeData.Data.Tags, ",")
+	m.Config = &providerConfig
 	return &m
 }
 

--- a/pkg/monitors/statuscake/statuscake-monitor.go
+++ b/pkg/monitors/statuscake/statuscake-monitor.go
@@ -211,12 +211,6 @@ func buildUpsertForm(m models.Monitor, cgroup string) url.Values {
 	if providerConfig != nil && len(providerConfig.FindString) > 0 {
 		f.Add("find_string", providerConfig.FindString)
 	}
-	if providerConfig != nil && len(providerConfig.RawPostData) > 0 {
-		f.Add("post_raw", providerConfig.RawPostData)
-	}
-	if providerConfig != nil && len(providerConfig.UserAgent) > 0 {
-		f.Add("user_agent", providerConfig.UserAgent)
-	}
 	return f
 }
 


### PR DESCRIPTION
This PR implements the `Equals` function in the statuscake operator. This ensures that the operator does not update all uptime checks during every round. Which could cause ratelimiting from Statuscake. My consideration for this implementation can be found below.

```It is mentioned in a comment in the code itself but because of the discrepency between the fields in the EndpointMonitor CR and the Statuscake API it is not immediately clear how to compare an old monitor with an updated monitor. The way I have elected to check this is to use the TestTags field to include some kind of identifier that should be updated on any change. So if the tags have changed then the monitor should be updated.```

I have added a comment in code to explain the reason for the implementation. Let me know if you have any other questions.