### PR TITLE
Improve StatusCake monitors with Caching and Smarter Retries.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,10 +88,13 @@ help: ## Display this help.
 ##@ Development
 
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
-	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+    $(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook \
+        paths="$$(go list ./... | grep -v 'pkg/monitors/statuscake')" \
+        output:crd:artifacts:config=config/crd/bases
 
-generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
-	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
+generate: controller-gen ## Generate code containing DeepCopy, etc.
+    $(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" \
+        paths="$$(go list ./... | grep -v 'pkg/monitors/statuscake')"
 
 fmt: ## Run go fmt against code.
 	go fmt ./...

--- a/pkg/monitors/statuscake/statuscake-mappers.go
+++ b/pkg/monitors/statuscake/statuscake-mappers.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stakater/IngressMonitorController/v2/pkg/models"
 )
 
-// StatusCakeMonitorMonitorToBaseMonitorMapper function to map Statuscake structure to Monitor
+// StatusCakeMonitorMonitorToBaseMonitorMapper maps StatusCakeMonitorData to the internal Monitor model
 func StatusCakeMonitorMonitorToBaseMonitorMapper(statuscakeData StatusCakeMonitorData) *models.Monitor {
 	var m models.Monitor
 	m.Name = statuscakeData.WebsiteName
@@ -16,12 +16,23 @@ func StatusCakeMonitorMonitorToBaseMonitorMapper(statuscakeData StatusCakeMonito
 	m.ID = statuscakeData.TestID
 
 	var providerConfig endpointmonitorv1alpha1.StatusCakeConfig
+	providerConfig.Paused = statuscakeData.Paused
+	providerConfig.TestType = statuscakeData.TestType
+	providerConfig.CheckRate = statuscakeData.CheckRate
+	providerConfig.ContactGroup = strings.Join(statuscakeData.ContactGroup, ",")
 	providerConfig.TestTags = strings.Join(statuscakeData.Tags, ",")
+	providerConfig.FollowRedirect = statuscakeData.FollowRedirect
+	providerConfig.Port = statuscakeData.Port
+	providerConfig.TriggerRate = statuscakeData.TriggerRate
+	providerConfig.FindString = statuscakeData.FindString
+	providerConfig.EnableSSLAlert = statuscakeData.EnableSSLAlert
+	providerConfig.Confirmation = int(statuscakeData.Confirmation)
+
 	m.Config = &providerConfig
 	return &m
 }
 
-// StatusCakeApiResponseDataToBaseMonitorMapper function to map Statuscake Uptime Test Response to Monitor
+// StatusCakeApiResponseDataToBaseMonitorMapper maps statuscake.UptimeTestResponse to the internal Monitor model
 func StatusCakeApiResponseDataToBaseMonitorMapper(statuscakeData statuscake.UptimeTestResponse) *models.Monitor {
 	var m models.Monitor
 	m.Name = statuscakeData.Data.Name
@@ -29,7 +40,22 @@ func StatusCakeApiResponseDataToBaseMonitorMapper(statuscakeData statuscake.Upti
 	m.ID = statuscakeData.Data.ID
 
 	var providerConfig endpointmonitorv1alpha1.StatusCakeConfig
+	providerConfig.Paused = statuscakeData.Data.Paused
+	providerConfig.TestType = string(statuscakeData.Data.TestType)
+	providerConfig.CheckRate = int(statuscakeData.Data.CheckRate)
+	providerConfig.ContactGroup = strings.Join(statuscakeData.Data.ContactGroups, ",")
 	providerConfig.TestTags = strings.Join(statuscakeData.Data.Tags, ",")
+	providerConfig.FollowRedirect = statuscakeData.Data.FollowRedirects
+	providerConfig.EnableSSLAlert = statuscakeData.Data.EnableSSLAlert
+	providerConfig.Confirmation = int(statuscakeData.Data.Confirmation)
+	if statuscakeData.Data.Port != nil {
+		providerConfig.Port = int(*statuscakeData.Data.Port)
+	}
+	providerConfig.TriggerRate = int(statuscakeData.Data.TriggerRate)
+	if statuscakeData.Data.FindString != nil {
+		providerConfig.FindString = *statuscakeData.Data.FindString
+	}
+
 	m.Config = &providerConfig
 	return &m
 }

--- a/pkg/monitors/statuscake/statuscake-monitor.go
+++ b/pkg/monitors/statuscake/statuscake-monitor.go
@@ -633,7 +633,7 @@ func (service *StatusCakeMonitorService) doRequest(req *http.Request) (*http.Res
 
 	// Empty response with 200 status might indicate rate limiting
 	if len(bodyBytes) == 0 && (resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusCreated) {
-		log.Info("Empty body received with success status code - possible rate limiting",
+		log.V(1).Info("Empty body received with success status code - possible rate limiting",
 			"method", req.Method,
 			"url", req.URL.String(),
 			"status", resp.StatusCode,
@@ -645,7 +645,7 @@ func (service *StatusCakeMonitorService) doRequest(req *http.Request) (*http.Res
 		// Create new request for retry
 		newReq, err := http.NewRequest(req.Method, req.URL.String(), nil)
 		if err != nil {
-			return &newResp, nil // Return what we have if we can't retry
+			return &newResp, nil // Return the empty response if new request can't be created
 		}
 
 		// Copy headers

--- a/pkg/monitors/statuscake/statuscake-responses.go
+++ b/pkg/monitors/statuscake/statuscake-responses.go
@@ -12,16 +12,22 @@ type StatusCakeMonitor struct {
 }
 
 type StatusCakeMonitorData struct {
-	TestID       string   `json:"id"`
-	Paused       bool     `json:"paused"`
-	WebsiteName  string   `json:"name"`
-	WebsiteURL   string   `json:"website_url"`
-	TestType     string   `json:"test_type"`
-	CheckRate    int      `json:"check_rate"`
-	ContactGroup []string `json:"contact_groups"`
-	Status       string   `json:"status"`
-	Tags         []string `json:"tags"`
-	Uptime       float64  `json:"uptime"`
+	TestID         string   `json:"id"`
+	Paused         bool     `json:"paused"`
+	WebsiteName    string   `json:"name"`
+	WebsiteURL     string   `json:"website_url"`
+	TestType       string   `json:"test_type"`
+	CheckRate      int      `json:"check_rate"`
+	ContactGroup   []string `json:"contact_groups"`
+	Confirmation   int32    `json:"confirmation"`
+	Status         string   `json:"status"`
+	Tags           []string `json:"tags"`
+	Uptime         float64  `json:"uptime"`
+	FollowRedirect bool     `json:"follow_redirects"`
+	EnableSSLAlert bool     `json:"enable_ssl_alert"`
+	Port           int      `json:"port,omitempty"`
+	TriggerRate    int      `json:"trigger_rate,omitempty"`
+	FindString     string   `json:"find_string,omitempty"`
 }
 type StatusCakeMonitorMetadata struct {
 	Page       int `json:"page"`


### PR DESCRIPTION
This PR revamps how our StatusCake monitor service works. Here’s a quick rundown:

-     Caching & Concurrency: We added a cache (with a background thread clearing it) to avoid hitting the StatusCake API every time. Plus, there’s a sync.Mutex to keep everything thread-safe.
-     Error Handling & Retries: We now have smarter retry logic for 429 (Too Many Requests) and other errors. There’s an exponential backoff plus a bit of randomness (jitter) to prevent retry storms( I run miltiple ingressmonitor controllers in single account )
-    Config Comparison: The Equal() method now checks each field in StatusCakeConfig instead of only looking at TestTags.

I've also added exclusion for controller-gen in makefile, so most people can run tests locally. 

