### PR TITLE
chore: migrate Renovate preset to recommended

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
+    "config:recommended"
   ],
   "schedule": ["monthly"],
   "vulnerabilityAlerts": {


### PR DESCRIPTION
## Summary
- migrate Renovate's deprecated `config:base` preset to `config:recommended`
- preserve the existing monthly schedule and vulnerability alert settings

## Verification
- `python3 -m json.tool renovate.json`
- `git diff --check`